### PR TITLE
Added configuration key for payment method types

### DIFF
--- a/src/AbstractStripeGatewayFactory.php
+++ b/src/AbstractStripeGatewayFactory.php
@@ -140,7 +140,7 @@ abstract class AbstractStripeGatewayFactory extends GatewayFactory
                 'publishable_key' => '',
                 'secret_key' => '',
                 'webhook_secret_keys' => [],
-                'payment_method_types' => ['card']
+                'payment_method_types' => ['card'],
             ]);
             $config->defaults($config['payum.default_options']);
             $config->offsetSet('payum.required_options', [

--- a/src/AbstractStripeGatewayFactory.php
+++ b/src/AbstractStripeGatewayFactory.php
@@ -140,6 +140,7 @@ abstract class AbstractStripeGatewayFactory extends GatewayFactory
                 'publishable_key' => '',
                 'secret_key' => '',
                 'webhook_secret_keys' => [],
+                'payment_method_types' => ['card']
             ]);
             $config->defaults($config['payum.default_options']);
             $config->offsetSet('payum.required_options', [
@@ -154,7 +155,8 @@ abstract class AbstractStripeGatewayFactory extends GatewayFactory
                 return new Keys(
                     $config['publishable_key'],
                     $config['secret_key'],
-                    $config['webhook_secret_keys']
+                    $config['webhook_secret_keys'],
+                    $config['payment_method_types']
                 );
             });
         }

--- a/src/Action/StripeCheckoutSession/ConvertPaymentAction.php
+++ b/src/Action/StripeCheckoutSession/ConvertPaymentAction.php
@@ -16,7 +16,6 @@ use Payum\Core\Request\Convert;
 
 final class ConvertPaymentAction implements ActionInterface, ApiAwareInterface, GatewayAwareInterface
 {
-
     use GatewayAwareTrait;
     use StripeApiAwareTrait {
         StripeApiAwareTrait::__construct as private __stripeApiAwareTraitConstruct;

--- a/src/Action/StripeCheckoutSession/ConvertPaymentAction.php
+++ b/src/Action/StripeCheckoutSession/ConvertPaymentAction.php
@@ -4,14 +4,29 @@ declare(strict_types=1);
 
 namespace FluxSE\PayumStripe\Action\StripeCheckoutSession;
 
+use FluxSE\PayumStripe\Action\Api\StripeApiAwareTrait;
 use Payum\Core\Action\ActionInterface;
+use Payum\Core\ApiAwareInterface;
 use Payum\Core\Bridge\Spl\ArrayObject;
 use Payum\Core\Exception\RequestNotSupportedException;
+use Payum\Core\GatewayAwareInterface;
+use Payum\Core\GatewayAwareTrait;
 use Payum\Core\Model\PaymentInterface;
 use Payum\Core\Request\Convert;
 
-final class ConvertPaymentAction implements ActionInterface
+final class ConvertPaymentAction implements ActionInterface, ApiAwareInterface, GatewayAwareInterface
 {
+
+    use GatewayAwareTrait;
+    use StripeApiAwareTrait {
+        StripeApiAwareTrait::__construct as private __stripeApiAwareTraitConstruct;
+    }
+
+    public function __construct()
+    {
+        $this->__stripeApiAwareTraitConstruct();
+    }
+
     public function execute($request): void
     {
         RequestNotSupportedException::assertSupports($this, $request);
@@ -37,7 +52,7 @@ final class ConvertPaymentAction implements ActionInterface
         }
 
         if (false === $details->offsetExists('payment_method_types')) {
-            $details->offsetSet('payment_method_types', ['card']);
+            $details->offsetSet('payment_method_types', $this->api->getPaymentMethodTypes());
         }
 
         $request->setResult($details);

--- a/src/Api/Keys.php
+++ b/src/Api/Keys.php
@@ -74,7 +74,7 @@ final class Keys implements KeysInterface
 
     public function addPaymentMethodType(string $paymentMethodType): void
     {
-        if(!$this->hasPaymentMethodType($paymentMethodType)) {
+        if (!$this->hasPaymentMethodType($paymentMethodType)) {
             $this->paymentMethodTypes[] = $paymentMethodType;
         }
     }

--- a/src/Api/Keys.php
+++ b/src/Api/Keys.php
@@ -12,6 +12,8 @@ final class Keys implements KeysInterface
     private $publishable;
     /** @var string */
     private $secret;
+    /** @var string[] */
+    private $paymentMethodTypes;
 
     /**
      * @param string[] $webhookSecretKeys
@@ -19,11 +21,13 @@ final class Keys implements KeysInterface
     public function __construct(
         string $publishable,
         string $secret,
-        array $webhookSecretKeys = []
+        array $webhookSecretKeys = [],
+        array $paymentMethodTypes = []
     ) {
         $this->publishable = $publishable;
         $this->secret = $secret;
         $this->webhookSecretKeys = $webhookSecretKeys;
+        $this->paymentMethodTypes = $paymentMethodTypes;
     }
 
     public function getSecretKey(): string
@@ -56,5 +60,27 @@ final class Keys implements KeysInterface
     public function setWebhookSecretKeys(array $webhookSecretKeys): void
     {
         $this->webhookSecretKeys = $webhookSecretKeys;
+    }
+
+    public function getPaymentMethodTypes(): array
+    {
+        return $this->paymentMethodTypes;
+    }
+
+    public function hasPaymentMethodType(string $paymentMethodType): bool
+    {
+        return in_array($paymentMethodType, $this->paymentMethodTypes);
+    }
+
+    public function addPaymentMethodType(string $paymentMethodType): void
+    {
+        if(!$this->hasPaymentMethodType($paymentMethodType)) {
+            $this->paymentMethodTypes[] = $paymentMethodType;
+        }
+    }
+
+    public function setPaymentMethodTypes(array $paymentMethodTypes): void
+    {
+        $this->paymentMethodTypes = $paymentMethodTypes;
     }
 }

--- a/src/Api/KeysInterface.php
+++ b/src/Api/KeysInterface.php
@@ -23,4 +23,18 @@ interface KeysInterface
     public function getSecretKey(): string;
 
     public function getPublishableKey(): string;
+
+    public function hasPaymentMethodType(string $paymentMethodType): bool;
+
+    /**
+     * @param string[] $paymentMethodTypes
+     */
+    public function setPaymentMethodTypes(array $paymentMethodTypes): void;
+
+    /**
+     * @return string[]
+     */
+    public function getPaymentMethodTypes(): array;
+
+    public function addPaymentMethodType(string $paymentMethodType): void;
 }

--- a/tests/Action/StripeCheckoutSession/ConvertPaymentActionTest.php
+++ b/tests/Action/StripeCheckoutSession/ConvertPaymentActionTest.php
@@ -5,7 +5,6 @@ namespace Tests\FluxSE\PayumStripe\Action\StripeCheckoutSession;
 use FluxSE\PayumStripe\Action\StripeCheckoutSession\ConvertPaymentAction;
 use FluxSE\PayumStripe\Api\KeysInterface;
 use Payum\Core\Action\ActionInterface;
-use Payum\Core\ApiAwareInterface;
 use Payum\Core\GatewayInterface;
 use Payum\Core\Model\Payment;
 use Payum\Core\Request\Capture;

--- a/tests/Action/StripeCheckoutSession/ConvertPaymentActionTest.php
+++ b/tests/Action/StripeCheckoutSession/ConvertPaymentActionTest.php
@@ -3,6 +3,7 @@
 namespace Tests\FluxSE\PayumStripe\Action\StripeCheckoutSession;
 
 use FluxSE\PayumStripe\Action\StripeCheckoutSession\ConvertPaymentAction;
+use FluxSE\PayumStripe\Api\KeysInterface;
 use Payum\Core\Action\ActionInterface;
 use Payum\Core\ApiAwareInterface;
 use Payum\Core\GatewayInterface;
@@ -10,16 +11,18 @@ use Payum\Core\Model\Payment;
 use Payum\Core\Request\Capture;
 use Payum\Core\Request\Convert;
 use PHPUnit\Framework\TestCase;
+use Tests\FluxSE\PayumStripe\Action\Api\ApiAwareActionTestTrait;
 
 final class ConvertPaymentActionTest extends TestCase
 {
+    use ApiAwareActionTestTrait;
+
     public function testShouldImplements()
     {
         $action = new ConvertPaymentAction();
 
         $this->assertInstanceOf(ActionInterface::class, $action);
         $this->assertNotInstanceOf(GatewayInterface::class, $action);
-        $this->assertNotInstanceOf(ApiAwareInterface::class, $action);
     }
 
     public function testSupports()
@@ -43,6 +46,16 @@ final class ConvertPaymentActionTest extends TestCase
         $request = new Convert($payment, 'array');
 
         $action = new ConvertPaymentAction();
+
+        $apiMock = $this->createApiMock(false);
+        $apiMock
+            ->expects($this->once())
+            ->method('getPaymentMethodTypes')
+            ->willReturn(['card'])
+        ;
+
+        $action->setApiClass(KeysInterface::class);
+        $action->setApi($apiMock);
 
         $supports = $action->supports($request);
         $this->assertTrue($supports);
@@ -83,6 +96,16 @@ final class ConvertPaymentActionTest extends TestCase
         $request = new Convert($payment, 'array');
 
         $action = new ConvertPaymentAction();
+
+        $apiMock = $this->createApiMock(false);
+        $apiMock
+            ->expects($this->once())
+            ->method('getPaymentMethodTypes')
+            ->willReturn(['card'])
+        ;
+
+        $action->setApiClass(KeysInterface::class);
+        $action->setApi($apiMock);
 
         $supports = $action->supports($request);
         $this->assertTrue($supports);
@@ -140,6 +163,16 @@ final class ConvertPaymentActionTest extends TestCase
 
         $action = new ConvertPaymentAction();
 
+        $apiMock = $this->createApiMock(false);
+        $apiMock
+            ->expects($this->once())
+            ->method('getPaymentMethodTypes')
+            ->willReturn(['card'])
+        ;
+
+        $action->setApiClass(KeysInterface::class);
+        $action->setApi($apiMock);
+
         $supports = $action->supports($request);
         $this->assertTrue($supports);
 
@@ -167,6 +200,16 @@ final class ConvertPaymentActionTest extends TestCase
         $request = new Convert($payment, 'array');
 
         $action = new ConvertPaymentAction();
+
+        $apiMock = $this->createApiMock(false);
+        $apiMock
+            ->expects($this->once())
+            ->method('getPaymentMethodTypes')
+            ->willReturn(['card'])
+        ;
+
+        $action->setApiClass(KeysInterface::class);
+        $action->setApi($apiMock);
 
         $supports = $action->supports($request);
         $this->assertTrue($supports);

--- a/tests/Api/KeysTest.php
+++ b/tests/Api/KeysTest.php
@@ -55,4 +55,33 @@ final class KeysTest extends TestCase
         $keys->addWebhookSecretKey('webhookKeyAdded');
         $this->assertEquals(['webhookKeyAdded'], $keys->getWebhookSecretKeys());
     }
+
+    public function testHasPaymentMethodType()
+    {
+        $keys = new Keys('', '', [], ['card']);
+
+        $this->assertTrue($keys->hasPaymentMethodType('card'));
+        $this->assertFalse($keys->hasPaymentMethodType('sepa_debit'));
+    }
+
+    public function testGetPaymentMethodTypes()
+    {
+        $keys = new Keys('', '', [], ['card']);
+
+        $this->assertEquals(['card'], $keys->getPaymentMethodTypes());
+    }
+
+    public function testSetPaymentMethodTypes()
+    {
+        $keys = new Keys('', '', [], ['card']);
+        $keys->setPaymentMethodTypes([]);
+        $this->assertEquals([], $keys->getPaymentMethodTypes());
+    }
+
+    public function testAddPaymentMethodType()
+    {
+        $keys = new Keys('', '', [], []);
+        $keys->addPaymentMethodType('card');
+        $this->assertEquals(['card'], $keys->getPaymentMethodTypes());
+    }
 }

--- a/tests/Api/KeysTest.php
+++ b/tests/Api/KeysTest.php
@@ -61,7 +61,7 @@ final class KeysTest extends TestCase
         $keys = new Keys('', '', [], ['card']);
 
         $this->assertTrue($keys->hasPaymentMethodType('card'));
-        $this->assertFalse($keys->hasPaymentMethodType('sepa_debit'));
+        $this->assertFalse($keys->hasPaymentMethodType('ideal'));
     }
 
     public function testGetPaymentMethodTypes()

--- a/tests/StripeGatewayFactoryTest.php
+++ b/tests/StripeGatewayFactoryTest.php
@@ -86,6 +86,7 @@ final class StripeGatewayFactoryTest extends TestCase
             'publishable_key' => '',
             'secret_key' => '',
             'webhook_secret_keys' => [],
+            'payment_method_types' => ['card']
         ], $config['payum.default_options']);
     }
 
@@ -139,6 +140,7 @@ final class StripeGatewayFactoryTest extends TestCase
             'webhook_secret_keys' => [
                 '123456',
             ],
+            'payment_method_types' => ['card']
         ];
 
         /** @var AbstractStripeGatewayFactory $factory */
@@ -149,6 +151,7 @@ final class StripeGatewayFactoryTest extends TestCase
         $this->assertEquals($defaults['publishable_key'], $config['publishable_key']);
         $this->assertEquals($defaults['secret_key'], $config['secret_key']);
         $this->assertEquals($defaults['webhook_secret_keys'], $config['webhook_secret_keys']);
+        $this->assertEquals($defaults['payment_method_types'], $config['payment_method_types']);
 
         // Allow to update the credentials
         $newCredentials = new ArrayObject([
@@ -158,6 +161,7 @@ final class StripeGatewayFactoryTest extends TestCase
             'webhook_secret_keys' => [
                 '654321',
             ],
+            'payment_method_types' => ['card']
         ]);
         $api = $config['payum.api']($newCredentials);
         $this->assertInstanceOf(KeysInterface::class, $api);

--- a/tests/StripeGatewayFactoryTest.php
+++ b/tests/StripeGatewayFactoryTest.php
@@ -86,7 +86,7 @@ final class StripeGatewayFactoryTest extends TestCase
             'publishable_key' => '',
             'secret_key' => '',
             'webhook_secret_keys' => [],
-            'payment_method_types' => ['card']
+            'payment_method_types' => ['card'],
         ], $config['payum.default_options']);
     }
 
@@ -140,7 +140,7 @@ final class StripeGatewayFactoryTest extends TestCase
             'webhook_secret_keys' => [
                 '123456',
             ],
-            'payment_method_types' => ['card']
+            'payment_method_types' => ['card'],
         ];
 
         /** @var AbstractStripeGatewayFactory $factory */
@@ -161,7 +161,7 @@ final class StripeGatewayFactoryTest extends TestCase
             'webhook_secret_keys' => [
                 '654321',
             ],
-            'payment_method_types' => ['card']
+            'payment_method_types' => ['card'],
         ]);
         $api = $config['payum.api']($newCredentials);
         $this->assertInstanceOf(KeysInterface::class, $api);


### PR DESCRIPTION
- new configuration key "payment_method_types" for multiple payment method types (e.g. card, sepa_debit, sofort, ideal)
- Updated unit-tests (missing in recent pull request)