### PR TITLE
Use StripeClient class

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     ],
     "require": {
         "payum/core": "^1.6",
-        "stripe/stripe-php": "^9"
+        "stripe/stripe-php": "^12"
     },
     "require-dev": {
         "phpunit/phpunit": "^8|^9",

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -17,17 +17,32 @@ parameters:
             message: '/Parameter #2 (\$arr2|\.\.\.\$replacements) of function array_replace expects array, mixed given\./'
             path: src/AbstractStripeGatewayFactory.php
         -
-            message: '/Parameter #[12] \$[^ ]+ of class FluxSE\\PayumStripe\\Api\\StripeCheckoutSessionApi constructor expects string, mixed given\./'
+            message: '/Parameter #[12] \$[^ ]+ of class FluxSE\\PayumStripe\\Api\\Stripe(CheckoutSession|Js)Api constructor expects string, mixed given\./'
             paths:
                 - src/StripeCheckoutSessionGatewayFactory.php
                 - src/StripeJsGatewayFactory.php
         -
-            message: '/Parameter #3 \$webhookSecretKeys of class FluxSE\\PayumStripe\\Api\\StripeCheckoutSessionApi constructor expects array<string>, mixed given\./'
+            message: '/Parameter #3 \$webhookSecretKeys of class FluxSE\\PayumStripe\\Api\\Stripe(CheckoutSession|Js)Api constructor expects array<string>, mixed given\./'
             paths:
                 - src/StripeCheckoutSessionGatewayFactory.php
                 - src/StripeJsGatewayFactory.php
         -
-            message: '/Parameter #4 \$paymentMethodTypes of class FluxSE\\PayumStripe\\Api\\StripeCheckoutSessionApi constructor expects array, mixed given\./'
+            message: '/Parameter #4 \$clientId of class FluxSE\\PayumStripe\\Api\\Stripe(CheckoutSession|Js)Api constructor expects string\|null, mixed given\./'
+            paths:
+                - src/StripeCheckoutSessionGatewayFactory.php
+                - src/StripeJsGatewayFactory.php
+        -
+            message: '/Parameter #5 \$stripeAccount of class FluxSE\\PayumStripe\\Api\\Stripe(CheckoutSession|Js)Api constructor expects string\|null, mixed given\./'
+            paths:
+                - src/StripeCheckoutSessionGatewayFactory.php
+                - src/StripeJsGatewayFactory.php
+        -
+            message: '/Parameter #6 \$stripeVersion of class FluxSE\\PayumStripe\\Api\\Stripe(CheckoutSession|Js)Api constructor expects string, mixed given\./'
+            paths:
+                - src/StripeCheckoutSessionGatewayFactory.php
+                - src/StripeJsGatewayFactory.php
+        -
+            message: '/Parameter #7 \$paymentMethodTypes of class FluxSE\\PayumStripe\\Api\\StripeCheckoutSessionApi constructor expects array, mixed given\./'
             path: src/StripeCheckoutSessionGatewayFactory.php
         -
             message: '/Parameter #1 \$templateName of class FluxSE\\PayumStripe\\Action\\StripeJs\\Api\\RenderStripeJsAction constructor expects string, mixed given\./'

--- a/src/AbstractStripeGatewayFactory.php
+++ b/src/AbstractStripeGatewayFactory.php
@@ -65,6 +65,7 @@ use FluxSE\PayumStripe\Action\SyncAction;
 use FluxSE\PayumStripe\Api\KeysAwareInterface;
 use Payum\Core\Bridge\Spl\ArrayObject;
 use Payum\Core\GatewayFactory;
+use Stripe\Util\ApiVersion;
 
 abstract class AbstractStripeGatewayFactory extends GatewayFactory
 {
@@ -182,6 +183,9 @@ abstract class AbstractStripeGatewayFactory extends GatewayFactory
             'publishable_key' => '',
             'secret_key' => '',
             'webhook_secret_keys' => [],
+            'client_id' => null,
+            'stripe_account' => null,
+            'stripe_version' => ApiVersion::CURRENT,
         ];
     }
 

--- a/src/Action/Api/Resource/AbstractAllAction.php
+++ b/src/Action/Api/Resource/AbstractAllAction.php
@@ -8,9 +8,7 @@ use FluxSE\PayumStripe\Action\Api\StripeApiAwareTrait;
 use FluxSE\PayumStripe\Request\Api\Resource\AllInterface;
 use Payum\Core\Exception\LogicException;
 use Payum\Core\Exception\RequestNotSupportedException;
-use Stripe\ApiOperations\All;
 use Stripe\Collection;
-use Stripe\Stripe;
 
 abstract class AbstractAllAction implements AllResourceActionInterface
 {
@@ -34,15 +32,12 @@ abstract class AbstractAllAction implements AllResourceActionInterface
      */
     public function allApiResource(AllInterface $request): Collection
     {
-        $apiResourceClass = $this->getApiResourceClass();
-        if (false === method_exists($apiResourceClass, 'all')) {
-            throw new LogicException(sprintf('This class "%s" is not an instance of "%s" !', $apiResourceClass, All::class));
+        $service = $this->getService();
+        if (false === method_exists($service, 'all')) {
+            throw new LogicException('This Stripe service does not have "all" method !');
         }
 
-        Stripe::setApiKey($this->api->getSecretKey());
-
-        /* @see All::all() */
-        return $apiResourceClass::all(
+        return $service->all(
             $request->getParameters(),
             $request->getOptions()
         );

--- a/src/Action/Api/Resource/AbstractCreateAction.php
+++ b/src/Action/Api/Resource/AbstractCreateAction.php
@@ -8,9 +8,7 @@ use FluxSE\PayumStripe\Action\Api\StripeApiAwareTrait;
 use FluxSE\PayumStripe\Request\Api\Resource\CreateInterface;
 use Payum\Core\Exception\LogicException;
 use Payum\Core\Exception\RequestNotSupportedException;
-use Stripe\ApiOperations\Create;
 use Stripe\ApiResource;
-use Stripe\Stripe;
 
 abstract class AbstractCreateAction implements CreateResourceActionInterface
 {
@@ -34,15 +32,12 @@ abstract class AbstractCreateAction implements CreateResourceActionInterface
      */
     public function createApiResource(CreateInterface $request): ApiResource
     {
-        $apiResourceClass = $this->getApiResourceClass();
-        if (false === method_exists($apiResourceClass, 'create')) {
-            throw new LogicException(sprintf('This class "%s" is not an instance of "%s" !', $apiResourceClass, Create::class));
+        $service = $this->getService();
+        if (false === method_exists($service, 'create')) {
+            throw new LogicException('This Stripe service does not have "create" method !');
         }
 
-        Stripe::setApiKey($this->api->getSecretKey());
-
-        /* @see Create::create() */
-        return $apiResourceClass::create(
+        return $service->create(
             $request->getParameters(),
             $request->getOptions()
         );

--- a/src/Action/Api/Resource/AbstractDeleteAction.php
+++ b/src/Action/Api/Resource/AbstractDeleteAction.php
@@ -8,10 +8,7 @@ use FluxSE\PayumStripe\Action\Api\StripeApiAwareTrait;
 use FluxSE\PayumStripe\Request\Api\Resource\DeleteInterface;
 use Payum\Core\Exception\LogicException;
 use Payum\Core\Exception\RequestNotSupportedException;
-use Stripe\ApiOperations\Delete;
-use Stripe\ApiOperations\Retrieve;
 use Stripe\ApiResource;
-use Stripe\Stripe;
 
 abstract class AbstractDeleteAction implements DeleteResourceActionInterface
 {
@@ -32,24 +29,20 @@ abstract class AbstractDeleteAction implements DeleteResourceActionInterface
 
     public function deleteApiResource(DeleteInterface $request): ApiResource
     {
-        $apiResourceClass = $this->getApiResourceClass();
-        if (false === method_exists($apiResourceClass, 'retrieve')) {
-            throw new LogicException(sprintf('This class "%s" is not an instance of "%s" !', $apiResourceClass, Retrieve::class));
+        $service = $this->getService();
+        if (false === method_exists($service, 'retrieve')) {
+            throw new LogicException('This Stripe service does not have "retrieve" method !');
         }
 
-        if (false === method_exists($apiResourceClass, 'delete')) {
-            throw new LogicException(sprintf('This class "%s" is not an instance of "%s" !', $apiResourceClass, Delete::class));
+        if (false === method_exists($service, 'delete')) {
+            throw new LogicException('This Stripe service does not have "delete" method !');
         }
 
-        Stripe::setApiKey($this->api->getSecretKey());
-
-        /** @see Retrieve::retrieve() */
-        $apiResource = $apiResourceClass::retrieve(
+        $apiResource = $service->retrieve(
             $request->getId(),
             $request->getOptions()
         );
 
-        /* @see Delete::delete() */
         return $apiResource->delete();
     }
 

--- a/src/Action/Api/Resource/AbstractRetrieveAction.php
+++ b/src/Action/Api/Resource/AbstractRetrieveAction.php
@@ -8,9 +8,7 @@ use FluxSE\PayumStripe\Action\Api\StripeApiAwareTrait;
 use FluxSE\PayumStripe\Request\Api\Resource\RetrieveInterface;
 use Payum\Core\Exception\LogicException;
 use Payum\Core\Exception\RequestNotSupportedException;
-use Stripe\ApiOperations\Retrieve;
 use Stripe\ApiResource;
-use Stripe\Stripe;
 
 abstract class AbstractRetrieveAction implements RetrieveResourceActionInterface
 {
@@ -31,15 +29,12 @@ abstract class AbstractRetrieveAction implements RetrieveResourceActionInterface
 
     public function retrieveApiResource(RetrieveInterface $request): ApiResource
     {
-        $apiResourceClass = $this->getApiResourceClass();
-        if (false === method_exists($apiResourceClass, 'retrieve')) {
-            throw new LogicException(sprintf('This class "%s" is not an instance of "%s" !', $apiResourceClass, Retrieve::class));
+        $service = $this->getService();
+        if (false === method_exists($service, 'retrieve')) {
+            throw new LogicException('This Stripe service does not have "retrieve" method !');
         }
 
-        Stripe::setApiKey($this->api->getSecretKey());
-
-        /* @see Retrieve::retrieve() */
-        return $apiResourceClass::retrieve(
+        return $service->retrieve(
             $request->getId(),
             $request->getOptions()
         );

--- a/src/Action/Api/Resource/AbstractUpdateAction.php
+++ b/src/Action/Api/Resource/AbstractUpdateAction.php
@@ -8,9 +8,7 @@ use FluxSE\PayumStripe\Action\Api\StripeApiAwareTrait;
 use FluxSE\PayumStripe\Request\Api\Resource\UpdateInterface;
 use Payum\Core\Exception\LogicException;
 use Payum\Core\Exception\RequestNotSupportedException;
-use Stripe\ApiOperations\Update;
 use Stripe\ApiResource;
-use Stripe\Stripe;
 
 abstract class AbstractUpdateAction implements UpdateResourceActionInterface
 {
@@ -31,15 +29,13 @@ abstract class AbstractUpdateAction implements UpdateResourceActionInterface
 
     public function updateApiResource(UpdateInterface $request): ApiResource
     {
-        $apiResourceClass = $this->getApiResourceClass();
-        if (false === method_exists($apiResourceClass, 'update')) {
-            throw new LogicException(sprintf('This class "%s" is not an instance of "%s" !', $apiResourceClass, Update::class));
+        $service = $this->getService();
+
+        if (false === method_exists($service, 'update')) {
+            throw new LogicException('This Stripe service does not have "update" method !');
         }
 
-        Stripe::setApiKey($this->api->getSecretKey());
-
-        /* @see Update::update() */
-        return $apiResourceClass::update(
+        return $service->update(
             $request->getId(),
             $request->getParameters(),
             $request->getOptions()

--- a/src/Action/Api/Resource/AllCouponAction.php
+++ b/src/Action/Api/Resource/AllCouponAction.php
@@ -6,11 +6,15 @@ namespace FluxSE\PayumStripe\Action\Api\Resource;
 
 use FluxSE\PayumStripe\Request\Api\Resource\AllCoupon;
 use FluxSE\PayumStripe\Request\Api\Resource\AllInterface;
-use Stripe\Coupon;
+use Stripe\Service\AbstractService;
+use Stripe\StripeClient;
 
 final class AllCouponAction extends AbstractAllAction
 {
-    protected $apiResourceClass = Coupon::class;
+    public function getStripeService(StripeClient $stripeClient): AbstractService
+    {
+        return $stripeClient->coupons;
+    }
 
     public function supportAlso(AllInterface $request): bool
     {

--- a/src/Action/Api/Resource/AllCustomerAction.php
+++ b/src/Action/Api/Resource/AllCustomerAction.php
@@ -6,11 +6,15 @@ namespace FluxSE\PayumStripe\Action\Api\Resource;
 
 use FluxSE\PayumStripe\Request\Api\Resource\AllCustomer;
 use FluxSE\PayumStripe\Request\Api\Resource\AllInterface;
-use Stripe\Customer;
+use Stripe\Service\AbstractService;
+use Stripe\StripeClient;
 
 final class AllCustomerAction extends AbstractAllAction
 {
-    protected $apiResourceClass = Customer::class;
+    public function getStripeService(StripeClient $stripeClient): AbstractService
+    {
+        return $stripeClient->customers;
+    }
 
     public function supportAlso(AllInterface $request): bool
     {

--- a/src/Action/Api/Resource/AllInvoiceAction.php
+++ b/src/Action/Api/Resource/AllInvoiceAction.php
@@ -6,11 +6,15 @@ namespace FluxSE\PayumStripe\Action\Api\Resource;
 
 use FluxSE\PayumStripe\Request\Api\Resource\AllInterface;
 use FluxSE\PayumStripe\Request\Api\Resource\AllInvoice;
-use Stripe\Invoice;
+use Stripe\Service\AbstractService;
+use Stripe\StripeClient;
 
 final class AllInvoiceAction extends AbstractAllAction
 {
-    protected $apiResourceClass = Invoice::class;
+    public function getStripeService(StripeClient $stripeClient): AbstractService
+    {
+        return $stripeClient->invoices;
+    }
 
     public function supportAlso(AllInterface $request): bool
     {

--- a/src/Action/Api/Resource/AllPlanAction.php
+++ b/src/Action/Api/Resource/AllPlanAction.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FluxSE\PayumStripe\Action\Api\Resource;
+
+use FluxSE\PayumStripe\Request\Api\Resource\AllInterface;
+use FluxSE\PayumStripe\Request\Api\Resource\AllPlan;
+use Stripe\Service\AbstractService;
+use Stripe\StripeClient;
+
+final class AllPlanAction extends AbstractAllAction
+{
+    public function getStripeService(StripeClient $stripeClient): AbstractService
+    {
+        return $stripeClient->plans;
+    }
+
+    public function supportAlso(AllInterface $request): bool
+    {
+        return $request instanceof AllPlan;
+    }
+}

--- a/src/Action/Api/Resource/AllPriceAction.php
+++ b/src/Action/Api/Resource/AllPriceAction.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FluxSE\PayumStripe\Action\Api\Resource;
+
+use FluxSE\PayumStripe\Request\Api\Resource\AllInterface;
+use FluxSE\PayumStripe\Request\Api\Resource\AllPrice;
+use Stripe\Service\AbstractService;
+use Stripe\StripeClient;
+
+final class AllPriceAction extends AbstractAllAction
+{
+    public function getStripeService(StripeClient $stripeClient): AbstractService
+    {
+        return $stripeClient->prices;
+    }
+
+    public function supportAlso(AllInterface $request): bool
+    {
+        return $request instanceof AllPrice;
+    }
+}

--- a/src/Action/Api/Resource/AllProductAction.php
+++ b/src/Action/Api/Resource/AllProductAction.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FluxSE\PayumStripe\Action\Api\Resource;
+
+use FluxSE\PayumStripe\Request\Api\Resource\AllInterface;
+use FluxSE\PayumStripe\Request\Api\Resource\AllProduct;
+use Stripe\Service\AbstractService;
+use Stripe\StripeClient;
+
+final class AllProductAction extends AbstractAllAction
+{
+    public function getStripeService(StripeClient $stripeClient): AbstractService
+    {
+        return $stripeClient->products;
+    }
+
+    public function supportAlso(AllInterface $request): bool
+    {
+        return $request instanceof AllProduct;
+    }
+}

--- a/src/Action/Api/Resource/AllSessionAction.php
+++ b/src/Action/Api/Resource/AllSessionAction.php
@@ -6,11 +6,15 @@ namespace FluxSE\PayumStripe\Action\Api\Resource;
 
 use FluxSE\PayumStripe\Request\Api\Resource\AllInterface;
 use FluxSE\PayumStripe\Request\Api\Resource\AllSession;
-use Stripe\Checkout\Session;
+use Stripe\Service\AbstractService;
+use Stripe\StripeClient;
 
 final class AllSessionAction extends AbstractAllAction
 {
-    protected $apiResourceClass = Session::class;
+    public function getStripeService(StripeClient $stripeClient): AbstractService
+    {
+        return $stripeClient->checkout->sessions;
+    }
 
     public function supportAlso(AllInterface $request): bool
     {

--- a/src/Action/Api/Resource/AllTaxRateAction.php
+++ b/src/Action/Api/Resource/AllTaxRateAction.php
@@ -6,11 +6,15 @@ namespace FluxSE\PayumStripe\Action\Api\Resource;
 
 use FluxSE\PayumStripe\Request\Api\Resource\AllInterface;
 use FluxSE\PayumStripe\Request\Api\Resource\AllTaxRate;
-use Stripe\TaxRate;
+use Stripe\Service\AbstractService;
+use Stripe\StripeClient;
 
 final class AllTaxRateAction extends AbstractAllAction
 {
-    protected $apiResourceClass = TaxRate::class;
+    public function getStripeService(StripeClient $stripeClient): AbstractService
+    {
+        return $stripeClient->taxRates;
+    }
 
     public function supportAlso(AllInterface $request): bool
     {

--- a/src/Action/Api/Resource/CancelPaymentIntentAction.php
+++ b/src/Action/Api/Resource/CancelPaymentIntentAction.php
@@ -9,10 +9,15 @@ use FluxSE\PayumStripe\Request\Api\Resource\CustomCallInterface;
 use FluxSE\PayumStripe\Request\Api\Resource\RetrieveInterface;
 use Stripe\ApiResource;
 use Stripe\PaymentIntent;
+use Stripe\Service\AbstractService;
+use Stripe\StripeClient;
 
 final class CancelPaymentIntentAction extends AbstractRetrieveAction
 {
-    protected $apiResourceClass = PaymentIntent::class;
+    public function getStripeService(StripeClient $stripeClient): AbstractService
+    {
+        return $stripeClient->paymentIntents;
+    }
 
     public function supportAlso(RetrieveInterface $request): bool
     {

--- a/src/Action/Api/Resource/CancelSetupIntentAction.php
+++ b/src/Action/Api/Resource/CancelSetupIntentAction.php
@@ -8,11 +8,16 @@ use FluxSE\PayumStripe\Request\Api\Resource\CancelSetupIntent;
 use FluxSE\PayumStripe\Request\Api\Resource\CustomCallInterface;
 use FluxSE\PayumStripe\Request\Api\Resource\RetrieveInterface;
 use Stripe\ApiResource;
+use Stripe\Service\AbstractService;
 use Stripe\SetupIntent;
+use Stripe\StripeClient;
 
 final class CancelSetupIntentAction extends AbstractRetrieveAction
 {
-    protected $apiResourceClass = SetupIntent::class;
+    public function getStripeService(StripeClient $stripeClient): AbstractService
+    {
+        return $stripeClient->setupIntents;
+    }
 
     public function supportAlso(RetrieveInterface $request): bool
     {

--- a/src/Action/Api/Resource/CancelSubscriptionAction.php
+++ b/src/Action/Api/Resource/CancelSubscriptionAction.php
@@ -8,11 +8,16 @@ use FluxSE\PayumStripe\Request\Api\Resource\CancelSubscription;
 use FluxSE\PayumStripe\Request\Api\Resource\CustomCallInterface;
 use FluxSE\PayumStripe\Request\Api\Resource\RetrieveInterface;
 use Stripe\ApiResource;
+use Stripe\Service\AbstractService;
+use Stripe\StripeClient;
 use Stripe\Subscription;
 
 final class CancelSubscriptionAction extends AbstractRetrieveAction
 {
-    protected $apiResourceClass = Subscription::class;
+    public function getStripeService(StripeClient $stripeClient): AbstractService
+    {
+        return $stripeClient->subscriptions;
+    }
 
     public function supportAlso(RetrieveInterface $request): bool
     {

--- a/src/Action/Api/Resource/CapturePaymentIntentAction.php
+++ b/src/Action/Api/Resource/CapturePaymentIntentAction.php
@@ -9,10 +9,15 @@ use FluxSE\PayumStripe\Request\Api\Resource\CustomCallInterface;
 use FluxSE\PayumStripe\Request\Api\Resource\RetrieveInterface;
 use Stripe\ApiResource;
 use Stripe\PaymentIntent;
+use Stripe\Service\AbstractService;
+use Stripe\StripeClient;
 
 final class CapturePaymentIntentAction extends AbstractRetrieveAction
 {
-    protected $apiResourceClass = PaymentIntent::class;
+    public function getStripeService(StripeClient $stripeClient): AbstractService
+    {
+        return $stripeClient->paymentIntents;
+    }
 
     public function supportAlso(RetrieveInterface $request): bool
     {

--- a/src/Action/Api/Resource/CreateCouponAction.php
+++ b/src/Action/Api/Resource/CreateCouponAction.php
@@ -6,11 +6,15 @@ namespace FluxSE\PayumStripe\Action\Api\Resource;
 
 use FluxSE\PayumStripe\Request\Api\Resource\CreateCoupon;
 use FluxSE\PayumStripe\Request\Api\Resource\CreateInterface;
-use Stripe\Coupon;
+use Stripe\Service\AbstractService;
+use Stripe\StripeClient;
 
 final class CreateCouponAction extends AbstractCreateAction
 {
-    protected $apiResourceClass = Coupon::class;
+    public function getStripeService(StripeClient $stripeClient): AbstractService
+    {
+        return $stripeClient->coupons;
+    }
 
     public function supportAlso(CreateInterface $request): bool
     {

--- a/src/Action/Api/Resource/CreateCustomerAction.php
+++ b/src/Action/Api/Resource/CreateCustomerAction.php
@@ -6,11 +6,15 @@ namespace FluxSE\PayumStripe\Action\Api\Resource;
 
 use FluxSE\PayumStripe\Request\Api\Resource\CreateCustomer;
 use FluxSE\PayumStripe\Request\Api\Resource\CreateInterface;
-use Stripe\Customer;
+use Stripe\Service\AbstractService;
+use Stripe\StripeClient;
 
 final class CreateCustomerAction extends AbstractCreateAction
 {
-    protected $apiResourceClass = Customer::class;
+    public function getStripeService(StripeClient $stripeClient): AbstractService
+    {
+        return $stripeClient->customers;
+    }
 
     public function supportAlso(CreateInterface $request): bool
     {

--- a/src/Action/Api/Resource/CreatePaymentIntentAction.php
+++ b/src/Action/Api/Resource/CreatePaymentIntentAction.php
@@ -6,11 +6,15 @@ namespace FluxSE\PayumStripe\Action\Api\Resource;
 
 use FluxSE\PayumStripe\Request\Api\Resource\CreateInterface;
 use FluxSE\PayumStripe\Request\Api\Resource\CreatePaymentIntent;
-use Stripe\PaymentIntent;
+use Stripe\Service\AbstractService;
+use Stripe\StripeClient;
 
 final class CreatePaymentIntentAction extends AbstractCreateAction
 {
-    protected $apiResourceClass = PaymentIntent::class;
+    public function getStripeService(StripeClient $stripeClient): AbstractService
+    {
+        return $stripeClient->paymentIntents;
+    }
 
     public function supportAlso(CreateInterface $request): bool
     {

--- a/src/Action/Api/Resource/CreatePaymentMethodAction.php
+++ b/src/Action/Api/Resource/CreatePaymentMethodAction.php
@@ -6,11 +6,15 @@ namespace FluxSE\PayumStripe\Action\Api\Resource;
 
 use FluxSE\PayumStripe\Request\Api\Resource\CreateInterface;
 use FluxSE\PayumStripe\Request\Api\Resource\CreatePaymentMethod;
-use Stripe\PaymentMethod;
+use Stripe\Service\AbstractService;
+use Stripe\StripeClient;
 
 final class CreatePaymentMethodAction extends AbstractCreateAction
 {
-    protected $apiResourceClass = PaymentMethod::class;
+    public function getStripeService(StripeClient $stripeClient): AbstractService
+    {
+        return $stripeClient->paymentMethods;
+    }
 
     public function supportAlso(CreateInterface $request): bool
     {

--- a/src/Action/Api/Resource/CreatePlanAction.php
+++ b/src/Action/Api/Resource/CreatePlanAction.php
@@ -6,11 +6,15 @@ namespace FluxSE\PayumStripe\Action\Api\Resource;
 
 use FluxSE\PayumStripe\Request\Api\Resource\CreateInterface;
 use FluxSE\PayumStripe\Request\Api\Resource\CreatePlan;
-use Stripe\Plan;
+use Stripe\Service\AbstractService;
+use Stripe\StripeClient;
 
 final class CreatePlanAction extends AbstractCreateAction
 {
-    protected $apiResourceClass = Plan::class;
+    public function getStripeService(StripeClient $stripeClient): AbstractService
+    {
+        return $stripeClient->plans;
+    }
 
     public function supportAlso(CreateInterface $request): bool
     {

--- a/src/Action/Api/Resource/CreatePriceAction.php
+++ b/src/Action/Api/Resource/CreatePriceAction.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FluxSE\PayumStripe\Action\Api\Resource;
+
+use FluxSE\PayumStripe\Request\Api\Resource\CreateInterface;
+use FluxSE\PayumStripe\Request\Api\Resource\CreatePrice;
+use Stripe\Service\AbstractService;
+use Stripe\StripeClient;
+
+final class CreatePriceAction extends AbstractCreateAction
+{
+    public function getStripeService(StripeClient $stripeClient): AbstractService
+    {
+        return $stripeClient->prices;
+    }
+
+    public function supportAlso(CreateInterface $request): bool
+    {
+        return $request instanceof CreatePrice;
+    }
+}

--- a/src/Action/Api/Resource/CreateProductAction.php
+++ b/src/Action/Api/Resource/CreateProductAction.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FluxSE\PayumStripe\Action\Api\Resource;
+
+use FluxSE\PayumStripe\Request\Api\Resource\CreateInterface;
+use FluxSE\PayumStripe\Request\Api\Resource\CreateProduct;
+use Stripe\Service\AbstractService;
+use Stripe\StripeClient;
+
+final class CreateProductAction extends AbstractCreateAction
+{
+    public function getStripeService(StripeClient $stripeClient): AbstractService
+    {
+        return $stripeClient->products;
+    }
+
+    public function supportAlso(CreateInterface $request): bool
+    {
+        return $request instanceof CreateProduct;
+    }
+}

--- a/src/Action/Api/Resource/CreateRefundAction.php
+++ b/src/Action/Api/Resource/CreateRefundAction.php
@@ -6,11 +6,15 @@ namespace FluxSE\PayumStripe\Action\Api\Resource;
 
 use FluxSE\PayumStripe\Request\Api\Resource\CreateInterface;
 use FluxSE\PayumStripe\Request\Api\Resource\CreateRefund;
-use Stripe\Refund;
+use Stripe\Service\AbstractService;
+use Stripe\StripeClient;
 
 final class CreateRefundAction extends AbstractCreateAction
 {
-    protected $apiResourceClass = Refund::class;
+    public function getStripeService(StripeClient $stripeClient): AbstractService
+    {
+        return $stripeClient->refunds;
+    }
 
     public function supportAlso(CreateInterface $request): bool
     {

--- a/src/Action/Api/Resource/CreateSessionAction.php
+++ b/src/Action/Api/Resource/CreateSessionAction.php
@@ -6,11 +6,15 @@ namespace FluxSE\PayumStripe\Action\Api\Resource;
 
 use FluxSE\PayumStripe\Request\Api\Resource\CreateInterface;
 use FluxSE\PayumStripe\Request\Api\Resource\CreateSession;
-use Stripe\Checkout\Session;
+use Stripe\Service\AbstractService;
+use Stripe\StripeClient;
 
 final class CreateSessionAction extends AbstractCreateAction
 {
-    protected $apiResourceClass = Session::class;
+    public function getStripeService(StripeClient $stripeClient): AbstractService
+    {
+        return $stripeClient->checkout->sessions;
+    }
 
     public function supportAlso(CreateInterface $request): bool
     {

--- a/src/Action/Api/Resource/CreateSetupIntentAction.php
+++ b/src/Action/Api/Resource/CreateSetupIntentAction.php
@@ -6,11 +6,15 @@ namespace FluxSE\PayumStripe\Action\Api\Resource;
 
 use FluxSE\PayumStripe\Request\Api\Resource\CreateInterface;
 use FluxSE\PayumStripe\Request\Api\Resource\CreateSetupIntent;
-use Stripe\SetupIntent;
+use Stripe\Service\AbstractService;
+use Stripe\StripeClient;
 
 final class CreateSetupIntentAction extends AbstractCreateAction
 {
-    protected $apiResourceClass = SetupIntent::class;
+    public function getStripeService(StripeClient $stripeClient): AbstractService
+    {
+        return $stripeClient->setupIntents;
+    }
 
     public function supportAlso(CreateInterface $request): bool
     {

--- a/src/Action/Api/Resource/CreateSubscriptionAction.php
+++ b/src/Action/Api/Resource/CreateSubscriptionAction.php
@@ -6,11 +6,15 @@ namespace FluxSE\PayumStripe\Action\Api\Resource;
 
 use FluxSE\PayumStripe\Request\Api\Resource\CreateInterface;
 use FluxSE\PayumStripe\Request\Api\Resource\CreateSubscription;
-use Stripe\Subscription;
+use Stripe\Service\AbstractService;
+use Stripe\StripeClient;
 
 final class CreateSubscriptionAction extends AbstractCreateAction
 {
-    protected $apiResourceClass = Subscription::class;
+    public function getStripeService(StripeClient $stripeClient): AbstractService
+    {
+        return $stripeClient->subscriptions;
+    }
 
     public function supportAlso(CreateInterface $request): bool
     {

--- a/src/Action/Api/Resource/CreateTaxRateAction.php
+++ b/src/Action/Api/Resource/CreateTaxRateAction.php
@@ -6,11 +6,15 @@ namespace FluxSE\PayumStripe\Action\Api\Resource;
 
 use FluxSE\PayumStripe\Request\Api\Resource\CreateInterface;
 use FluxSE\PayumStripe\Request\Api\Resource\CreateTaxRate;
-use Stripe\TaxRate;
+use Stripe\Service\AbstractService;
+use Stripe\StripeClient;
 
 final class CreateTaxRateAction extends AbstractCreateAction
 {
-    protected $apiResourceClass = TaxRate::class;
+    public function getStripeService(StripeClient $stripeClient): AbstractService
+    {
+        return $stripeClient->taxRates;
+    }
 
     public function supportAlso(CreateInterface $request): bool
     {

--- a/src/Action/Api/Resource/DeleteCouponAction.php
+++ b/src/Action/Api/Resource/DeleteCouponAction.php
@@ -6,11 +6,15 @@ namespace FluxSE\PayumStripe\Action\Api\Resource;
 
 use FluxSE\PayumStripe\Request\Api\Resource\DeleteCoupon;
 use FluxSE\PayumStripe\Request\Api\Resource\DeleteInterface;
-use Stripe\Coupon;
+use Stripe\Service\AbstractService;
+use Stripe\StripeClient;
 
 final class DeleteCouponAction extends AbstractDeleteAction
 {
-    protected $apiResourceClass = Coupon::class;
+    public function getStripeService(StripeClient $stripeClient): AbstractService
+    {
+        return $stripeClient->coupons;
+    }
 
     public function supportAlso(DeleteInterface $request): bool
     {

--- a/src/Action/Api/Resource/DeletePlanAction.php
+++ b/src/Action/Api/Resource/DeletePlanAction.php
@@ -6,11 +6,15 @@ namespace FluxSE\PayumStripe\Action\Api\Resource;
 
 use FluxSE\PayumStripe\Request\Api\Resource\DeleteInterface;
 use FluxSE\PayumStripe\Request\Api\Resource\DeletePlan;
-use Stripe\Plan;
+use Stripe\Service\AbstractService;
+use Stripe\StripeClient;
 
 final class DeletePlanAction extends AbstractDeleteAction
 {
-    protected $apiResourceClass = Plan::class;
+    public function getStripeService(StripeClient $stripeClient): AbstractService
+    {
+        return $stripeClient->plans;
+    }
 
     public function supportAlso(DeleteInterface $request): bool
     {

--- a/src/Action/Api/Resource/DeleteProductAction.php
+++ b/src/Action/Api/Resource/DeleteProductAction.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FluxSE\PayumStripe\Action\Api\Resource;
+
+use FluxSE\PayumStripe\Request\Api\Resource\DeleteInterface;
+use FluxSE\PayumStripe\Request\Api\Resource\DeleteProduct;
+use Stripe\Service\AbstractService;
+use Stripe\StripeClient;
+
+final class DeleteProductAction extends AbstractDeleteAction
+{
+    public function getStripeService(StripeClient $stripeClient): AbstractService
+    {
+        return $stripeClient->products;
+    }
+
+    public function supportAlso(DeleteInterface $request): bool
+    {
+        return $request instanceof DeleteProduct;
+    }
+}

--- a/src/Action/Api/Resource/ExpireSessionAction.php
+++ b/src/Action/Api/Resource/ExpireSessionAction.php
@@ -9,10 +9,15 @@ use FluxSE\PayumStripe\Request\Api\Resource\ExpireSession;
 use FluxSE\PayumStripe\Request\Api\Resource\RetrieveInterface;
 use Stripe\ApiResource;
 use Stripe\Checkout\Session;
+use Stripe\Service\AbstractService;
+use Stripe\StripeClient;
 
 final class ExpireSessionAction extends AbstractRetrieveAction
 {
-    protected $apiResourceClass = Session::class;
+    public function getStripeService(StripeClient $stripeClient): AbstractService
+    {
+        return $stripeClient->checkout->sessions;
+    }
 
     public function supportAlso(RetrieveInterface $request): bool
     {

--- a/src/Action/Api/Resource/ResourceActionInterface.php
+++ b/src/Action/Api/Resource/ResourceActionInterface.php
@@ -6,10 +6,10 @@ namespace FluxSE\PayumStripe\Action\Api\Resource;
 
 use Payum\Core\Action\ActionInterface;
 use Payum\Core\ApiAwareInterface;
+use Stripe\Service\AbstractService;
+use Stripe\StripeClient;
 
 interface ResourceActionInterface extends ActionInterface, ApiAwareInterface
 {
-    public function getApiResourceClass(): string;
-
-    public function setApiResourceClass(string $apiResourceClass): void;
+    public function getStripeService(StripeClient $stripeClient): AbstractService;
 }

--- a/src/Action/Api/Resource/ResourceAwareActionTrait.php
+++ b/src/Action/Api/Resource/ResourceAwareActionTrait.php
@@ -4,18 +4,24 @@ declare(strict_types=1);
 
 namespace FluxSE\PayumStripe\Action\Api\Resource;
 
+use FluxSE\PayumStripe\Api\StripeClientAwareInterface;
+use Payum\Core\Exception\LogicException;
+use Stripe\Service\AbstractService;
+use Stripe\StripeClient;
+
+/**
+ * @property StripeClientAwareInterface $api
+ */
 trait ResourceAwareActionTrait
 {
-    /** @var string */
-    protected $apiResourceClass = '';
+    abstract public function getStripeService(StripeClient $stripeClient): AbstractService;
 
-    public function getApiResourceClass(): string
+    protected function getService(): AbstractService
     {
-        return $this->apiResourceClass;
-    }
+        if (null === $this->api) {
+            throw new LogicException('Api class not found !');
+        }
 
-    public function setApiResourceClass(string $apiResourceClass): void
-    {
-        $this->apiResourceClass = $apiResourceClass;
+        return $this->getStripeService($this->api->getStripeClient());
     }
 }

--- a/src/Action/Api/Resource/RetrieveChargeAction.php
+++ b/src/Action/Api/Resource/RetrieveChargeAction.php
@@ -6,11 +6,15 @@ namespace FluxSE\PayumStripe\Action\Api\Resource;
 
 use FluxSE\PayumStripe\Request\Api\Resource\RetrieveCharge;
 use FluxSE\PayumStripe\Request\Api\Resource\RetrieveInterface;
-use Stripe\Charge;
+use Stripe\Service\AbstractService;
+use Stripe\StripeClient;
 
 final class RetrieveChargeAction extends AbstractRetrieveAction
 {
-    protected $apiResourceClass = Charge::class;
+    public function getStripeService(StripeClient $stripeClient): AbstractService
+    {
+        return $stripeClient->charges;
+    }
 
     public function supportAlso(RetrieveInterface $request): bool
     {

--- a/src/Action/Api/Resource/RetrieveCouponAction.php
+++ b/src/Action/Api/Resource/RetrieveCouponAction.php
@@ -6,11 +6,15 @@ namespace FluxSE\PayumStripe\Action\Api\Resource;
 
 use FluxSE\PayumStripe\Request\Api\Resource\RetrieveCoupon;
 use FluxSE\PayumStripe\Request\Api\Resource\RetrieveInterface;
-use Stripe\Coupon;
+use Stripe\Service\AbstractService;
+use Stripe\StripeClient;
 
 final class RetrieveCouponAction extends AbstractRetrieveAction
 {
-    protected $apiResourceClass = Coupon::class;
+    public function getStripeService(StripeClient $stripeClient): AbstractService
+    {
+        return $stripeClient->coupons;
+    }
 
     public function supportAlso(RetrieveInterface $request): bool
     {

--- a/src/Action/Api/Resource/RetrieveCustomerAction.php
+++ b/src/Action/Api/Resource/RetrieveCustomerAction.php
@@ -6,11 +6,15 @@ namespace FluxSE\PayumStripe\Action\Api\Resource;
 
 use FluxSE\PayumStripe\Request\Api\Resource\RetrieveCustomer;
 use FluxSE\PayumStripe\Request\Api\Resource\RetrieveInterface;
-use Stripe\Customer;
+use Stripe\Service\AbstractService;
+use Stripe\StripeClient;
 
 final class RetrieveCustomerAction extends AbstractRetrieveAction
 {
-    protected $apiResourceClass = Customer::class;
+    public function getStripeService(StripeClient $stripeClient): AbstractService
+    {
+        return $stripeClient->customers;
+    }
 
     public function supportAlso(RetrieveInterface $request): bool
     {

--- a/src/Action/Api/Resource/RetrieveInvoiceAction.php
+++ b/src/Action/Api/Resource/RetrieveInvoiceAction.php
@@ -6,11 +6,15 @@ namespace FluxSE\PayumStripe\Action\Api\Resource;
 
 use FluxSE\PayumStripe\Request\Api\Resource\RetrieveInterface;
 use FluxSE\PayumStripe\Request\Api\Resource\RetrieveInvoice;
-use Stripe\Invoice;
+use Stripe\Service\AbstractService;
+use Stripe\StripeClient;
 
 final class RetrieveInvoiceAction extends AbstractRetrieveAction
 {
-    protected $apiResourceClass = Invoice::class;
+    public function getStripeService(StripeClient $stripeClient): AbstractService
+    {
+        return $stripeClient->invoices;
+    }
 
     public function supportAlso(RetrieveInterface $request): bool
     {

--- a/src/Action/Api/Resource/RetrievePaymentIntentAction.php
+++ b/src/Action/Api/Resource/RetrievePaymentIntentAction.php
@@ -6,11 +6,15 @@ namespace FluxSE\PayumStripe\Action\Api\Resource;
 
 use FluxSE\PayumStripe\Request\Api\Resource\RetrieveInterface;
 use FluxSE\PayumStripe\Request\Api\Resource\RetrievePaymentIntent;
-use Stripe\PaymentIntent;
+use Stripe\Service\AbstractService;
+use Stripe\StripeClient;
 
 final class RetrievePaymentIntentAction extends AbstractRetrieveAction
 {
-    protected $apiResourceClass = PaymentIntent::class;
+    public function getStripeService(StripeClient $stripeClient): AbstractService
+    {
+        return $stripeClient->paymentIntents;
+    }
 
     public function supportAlso(RetrieveInterface $request): bool
     {

--- a/src/Action/Api/Resource/RetrievePaymentMethodAction.php
+++ b/src/Action/Api/Resource/RetrievePaymentMethodAction.php
@@ -6,11 +6,15 @@ namespace FluxSE\PayumStripe\Action\Api\Resource;
 
 use FluxSE\PayumStripe\Request\Api\Resource\RetrieveInterface;
 use FluxSE\PayumStripe\Request\Api\Resource\RetrievePaymentMethod;
-use Stripe\PaymentMethod;
+use Stripe\Service\AbstractService;
+use Stripe\StripeClient;
 
 final class RetrievePaymentMethodAction extends AbstractRetrieveAction
 {
-    protected $apiResourceClass = PaymentMethod::class;
+    public function getStripeService(StripeClient $stripeClient): AbstractService
+    {
+        return $stripeClient->paymentMethods;
+    }
 
     public function supportAlso(RetrieveInterface $request): bool
     {

--- a/src/Action/Api/Resource/RetrievePlanAction.php
+++ b/src/Action/Api/Resource/RetrievePlanAction.php
@@ -6,11 +6,15 @@ namespace FluxSE\PayumStripe\Action\Api\Resource;
 
 use FluxSE\PayumStripe\Request\Api\Resource\RetrieveInterface;
 use FluxSE\PayumStripe\Request\Api\Resource\RetrievePlan;
-use Stripe\Plan;
+use Stripe\Service\AbstractService;
+use Stripe\StripeClient;
 
 final class RetrievePlanAction extends AbstractRetrieveAction
 {
-    protected $apiResourceClass = Plan::class;
+    public function getStripeService(StripeClient $stripeClient): AbstractService
+    {
+        return $stripeClient->plans;
+    }
 
     public function supportAlso(RetrieveInterface $request): bool
     {

--- a/src/Action/Api/Resource/RetrievePriceAction.php
+++ b/src/Action/Api/Resource/RetrievePriceAction.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FluxSE\PayumStripe\Action\Api\Resource;
+
+use FluxSE\PayumStripe\Request\Api\Resource\RetrieveInterface;
+use FluxSE\PayumStripe\Request\Api\Resource\RetrievePrice;
+use Stripe\Service\AbstractService;
+use Stripe\StripeClient;
+
+final class RetrievePriceAction extends AbstractRetrieveAction
+{
+    public function getStripeService(StripeClient $stripeClient): AbstractService
+    {
+        return $stripeClient->prices;
+    }
+
+    public function supportAlso(RetrieveInterface $request): bool
+    {
+        return $request instanceof RetrievePrice;
+    }
+}

--- a/src/Action/Api/Resource/RetrieveProductAction.php
+++ b/src/Action/Api/Resource/RetrieveProductAction.php
@@ -6,11 +6,15 @@ namespace FluxSE\PayumStripe\Action\Api\Resource;
 
 use FluxSE\PayumStripe\Request\Api\Resource\RetrieveInterface;
 use FluxSE\PayumStripe\Request\Api\Resource\RetrieveProduct;
-use Stripe\Product;
+use Stripe\Service\AbstractService;
+use Stripe\StripeClient;
 
 final class RetrieveProductAction extends AbstractRetrieveAction
 {
-    protected $apiResourceClass = Product::class;
+    public function getStripeService(StripeClient $stripeClient): AbstractService
+    {
+        return $stripeClient->products;
+    }
 
     public function supportAlso(RetrieveInterface $request): bool
     {

--- a/src/Action/Api/Resource/RetrieveSessionAction.php
+++ b/src/Action/Api/Resource/RetrieveSessionAction.php
@@ -6,11 +6,15 @@ namespace FluxSE\PayumStripe\Action\Api\Resource;
 
 use FluxSE\PayumStripe\Request\Api\Resource\RetrieveInterface;
 use FluxSE\PayumStripe\Request\Api\Resource\RetrieveSession;
-use Stripe\Checkout\Session;
+use Stripe\Service\AbstractService;
+use Stripe\StripeClient;
 
 final class RetrieveSessionAction extends AbstractRetrieveAction
 {
-    protected $apiResourceClass = Session::class;
+    public function getStripeService(StripeClient $stripeClient): AbstractService
+    {
+        return $stripeClient->checkout->sessions;
+    }
 
     public function supportAlso(RetrieveInterface $request): bool
     {

--- a/src/Action/Api/Resource/RetrieveSetupIntentAction.php
+++ b/src/Action/Api/Resource/RetrieveSetupIntentAction.php
@@ -6,11 +6,15 @@ namespace FluxSE\PayumStripe\Action\Api\Resource;
 
 use FluxSE\PayumStripe\Request\Api\Resource\RetrieveInterface;
 use FluxSE\PayumStripe\Request\Api\Resource\RetrieveSetupIntent;
-use Stripe\SetupIntent;
+use Stripe\Service\AbstractService;
+use Stripe\StripeClient;
 
 final class RetrieveSetupIntentAction extends AbstractRetrieveAction
 {
-    protected $apiResourceClass = SetupIntent::class;
+    public function getStripeService(StripeClient $stripeClient): AbstractService
+    {
+        return $stripeClient->setupIntents;
+    }
 
     public function supportAlso(RetrieveInterface $request): bool
     {

--- a/src/Action/Api/Resource/RetrieveSubscriptionAction.php
+++ b/src/Action/Api/Resource/RetrieveSubscriptionAction.php
@@ -6,11 +6,15 @@ namespace FluxSE\PayumStripe\Action\Api\Resource;
 
 use FluxSE\PayumStripe\Request\Api\Resource\RetrieveInterface;
 use FluxSE\PayumStripe\Request\Api\Resource\RetrieveSubscription;
-use Stripe\Subscription;
+use Stripe\Service\AbstractService;
+use Stripe\StripeClient;
 
 final class RetrieveSubscriptionAction extends AbstractRetrieveAction
 {
-    protected $apiResourceClass = Subscription::class;
+    public function getStripeService(StripeClient $stripeClient): AbstractService
+    {
+        return $stripeClient->subscriptions;
+    }
 
     public function supportAlso(RetrieveInterface $request): bool
     {

--- a/src/Action/Api/Resource/UpdateCouponAction.php
+++ b/src/Action/Api/Resource/UpdateCouponAction.php
@@ -6,11 +6,15 @@ namespace FluxSE\PayumStripe\Action\Api\Resource;
 
 use FluxSE\PayumStripe\Request\Api\Resource\UpdateCoupon;
 use FluxSE\PayumStripe\Request\Api\Resource\UpdateInterface;
-use Stripe\Coupon;
+use Stripe\Service\AbstractService;
+use Stripe\StripeClient;
 
 final class UpdateCouponAction extends AbstractUpdateAction
 {
-    protected $apiResourceClass = Coupon::class;
+    public function getStripeService(StripeClient $stripeClient): AbstractService
+    {
+        return $stripeClient->coupons;
+    }
 
     public function supportAlso(UpdateInterface $request): bool
     {

--- a/src/Action/Api/Resource/UpdatePaymentIntentAction.php
+++ b/src/Action/Api/Resource/UpdatePaymentIntentAction.php
@@ -6,11 +6,15 @@ namespace FluxSE\PayumStripe\Action\Api\Resource;
 
 use FluxSE\PayumStripe\Request\Api\Resource\UpdateInterface;
 use FluxSE\PayumStripe\Request\Api\Resource\UpdatePaymentIntent;
-use Stripe\PaymentIntent;
+use Stripe\Service\AbstractService;
+use Stripe\StripeClient;
 
 final class UpdatePaymentIntentAction extends AbstractUpdateAction
 {
-    protected $apiResourceClass = PaymentIntent::class;
+    public function getStripeService(StripeClient $stripeClient): AbstractService
+    {
+        return $stripeClient->paymentIntents;
+    }
 
     public function supportAlso(UpdateInterface $request): bool
     {

--- a/src/Action/Api/Resource/UpdatePlanAction.php
+++ b/src/Action/Api/Resource/UpdatePlanAction.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FluxSE\PayumStripe\Action\Api\Resource;
+
+use FluxSE\PayumStripe\Request\Api\Resource\UpdateInterface;
+use FluxSE\PayumStripe\Request\Api\Resource\UpdatePlan;
+use Stripe\Service\AbstractService;
+use Stripe\StripeClient;
+
+final class UpdatePlanAction extends AbstractUpdateAction
+{
+    public function getStripeService(StripeClient $stripeClient): AbstractService
+    {
+        return $stripeClient->plans;
+    }
+
+    public function supportAlso(UpdateInterface $request): bool
+    {
+        return $request instanceof UpdatePlan;
+    }
+}

--- a/src/Action/Api/Resource/UpdatePriceAction.php
+++ b/src/Action/Api/Resource/UpdatePriceAction.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FluxSE\PayumStripe\Action\Api\Resource;
+
+use FluxSE\PayumStripe\Request\Api\Resource\UpdateInterface;
+use FluxSE\PayumStripe\Request\Api\Resource\UpdatePrice;
+use Stripe\Service\AbstractService;
+use Stripe\StripeClient;
+
+final class UpdatePriceAction extends AbstractUpdateAction
+{
+    public function getStripeService(StripeClient $stripeClient): AbstractService
+    {
+        return $stripeClient->prices;
+    }
+
+    public function supportAlso(UpdateInterface $request): bool
+    {
+        return $request instanceof UpdatePrice;
+    }
+}

--- a/src/Action/Api/Resource/UpdateProductAction.php
+++ b/src/Action/Api/Resource/UpdateProductAction.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FluxSE\PayumStripe\Action\Api\Resource;
+
+use FluxSE\PayumStripe\Request\Api\Resource\UpdateInterface;
+use FluxSE\PayumStripe\Request\Api\Resource\UpdateProduct;
+use Stripe\Service\AbstractService;
+use Stripe\StripeClient;
+
+final class UpdateProductAction extends AbstractUpdateAction
+{
+    public function getStripeService(StripeClient $stripeClient): AbstractService
+    {
+        return $stripeClient->products;
+    }
+
+    public function supportAlso(UpdateInterface $request): bool
+    {
+        return $request instanceof UpdateProduct;
+    }
+}

--- a/src/Action/Api/Resource/UpdateSubscriptionAction.php
+++ b/src/Action/Api/Resource/UpdateSubscriptionAction.php
@@ -6,11 +6,15 @@ namespace FluxSE\PayumStripe\Action\Api\Resource;
 
 use FluxSE\PayumStripe\Request\Api\Resource\UpdateInterface;
 use FluxSE\PayumStripe\Request\Api\Resource\UpdateSubscription;
-use Stripe\Subscription;
+use Stripe\Service\AbstractService;
+use Stripe\StripeClient;
 
 final class UpdateSubscriptionAction extends AbstractUpdateAction
 {
-    protected $apiResourceClass = Subscription::class;
+    public function getStripeService(StripeClient $stripeClient): AbstractService
+    {
+        return $stripeClient->subscriptions;
+    }
 
     public function supportAlso(UpdateInterface $request): bool
     {

--- a/src/Action/Api/StripeApiAwareTrait.php
+++ b/src/Action/Api/StripeApiAwareTrait.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace FluxSE\PayumStripe\Action\Api;
 
-use FluxSE\PayumStripe\Api\KeysAwareInterface;
+use FluxSE\PayumStripe\Api\StripeClientAwareInterface;
 use Payum\Core\ApiAwareTrait;
 
 /**
- * @property KeysAwareInterface $api
+ * @property StripeClientAwareInterface $api
  */
 trait StripeApiAwareTrait
 {
@@ -21,7 +21,7 @@ trait StripeApiAwareTrait
 
     protected function initApiClass(): void
     {
-        $this->apiClass = KeysAwareInterface::class;
+        $this->apiClass = StripeClientAwareInterface::class;
     }
 
     /**

--- a/src/Api/KeysAwareTrait.php
+++ b/src/Api/KeysAwareTrait.php
@@ -8,8 +8,10 @@ trait KeysAwareTrait
 {
     /** @var string[] */
     private $webhookSecretKeys;
+
     /** @var string */
     private $publishable;
+
     /** @var string */
     private $secret;
 
@@ -43,7 +45,7 @@ trait KeysAwareTrait
 
     public function hasWebhookSecretKey(string $webhookSecretKey): bool
     {
-        return in_array($webhookSecretKey, $this->webhookSecretKeys);
+        return in_array($webhookSecretKey, $this->webhookSecretKeys, true);
     }
 
     public function addWebhookSecretKey(string $webhookSecretKey): void

--- a/src/Api/StripeCheckoutSessionApi.php
+++ b/src/Api/StripeCheckoutSessionApi.php
@@ -4,10 +4,12 @@ declare(strict_types=1);
 
 namespace FluxSE\PayumStripe\Api;
 
+use Stripe\Util\ApiVersion;
+
 final class StripeCheckoutSessionApi implements StripeCheckoutSessionApiInterface
 {
-    use KeysAwareTrait {
-        KeysAwareTrait::__construct as private __keysAwareTraitConstruct;
+    use StripeClientAwareTrait {
+        StripeClientAwareTrait::__construct as private __stripeClientAwareTraitConstruct;
     }
 
     use PaymentMethodTypesAwareTrait {
@@ -21,9 +23,19 @@ final class StripeCheckoutSessionApi implements StripeCheckoutSessionApiInterfac
         string $publishable,
         string $secret,
         array $webhookSecretKeys = [],
+        ?string $clientId = null,
+        ?string $stripeAccount = null,
+        string $stripeVersion = ApiVersion::CURRENT,
         array $paymentMethodTypes = self::DEFAULT_PAYMENT_METHOD_TYPES
     ) {
-        $this->__keysAwareTraitConstruct($publishable, $secret, $webhookSecretKeys);
+        $this->__stripeClientAwareTraitConstruct(
+            $publishable,
+            $secret,
+            $webhookSecretKeys,
+            $clientId,
+            $stripeAccount,
+            $stripeVersion
+        );
         $this->__paymentMethodTypesAwareTraitConstruct($paymentMethodTypes);
     }
 }

--- a/src/Api/StripeCheckoutSessionApiInterface.php
+++ b/src/Api/StripeCheckoutSessionApiInterface.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace FluxSE\PayumStripe\Api;
 
-interface StripeCheckoutSessionApiInterface extends KeysAwareInterface, PaymentMethodTypesAwareInterface
+interface StripeCheckoutSessionApiInterface extends StripeClientAwareInterface, PaymentMethodTypesAwareInterface
 {
     public const DEFAULT_PAYMENT_METHOD_TYPES = [];
 }

--- a/src/Api/StripeClientAwareInterface.php
+++ b/src/Api/StripeClientAwareInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FluxSE\PayumStripe\Api;
+
+use Stripe\StripeClient;
+
+interface StripeClientAwareInterface extends KeysAwareInterface
+{
+    public function getStripeClient(): StripeClient;
+}

--- a/src/Api/StripeClientAwareTrait.php
+++ b/src/Api/StripeClientAwareTrait.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FluxSE\PayumStripe\Api;
+
+use Stripe\StripeClient;
+use Stripe\Util\ApiVersion;
+
+trait StripeClientAwareTrait
+{
+    use KeysAwareTrait {
+        KeysAwareTrait::__construct as private __keysAwareTraitConstruct;
+    }
+
+    /** @var null|StripeClient */
+    private $stripeClient = null;
+
+    /** @var string|null */
+    private $clientId = null;
+
+    /** @var string|null */
+    private $stripeAccount = null;
+
+    /** @var string */
+    private $stripeVersion = '';
+
+    /**
+     * @param string[] $webhookSecretKeys
+     */
+    public function __construct(
+        string $publishable,
+        string $secret,
+        array $webhookSecretKeys = [],
+        ?string $clientId = null,
+        ?string $stripeAccount = null,
+        string $stripeVersion = ApiVersion::CURRENT
+    ) {
+        $this->__keysAwareTraitConstruct($publishable, $secret, $webhookSecretKeys);
+        $this->clientId = $clientId;
+        $this->stripeAccount = $stripeAccount;
+        $this->stripeVersion = $stripeVersion;
+    }
+
+    public function getStripeClient(): StripeClient
+    {
+        if (null === $this->stripeClient) {
+            $this->stripeClient = new StripeClient([
+                'api_key' => $this->getSecretKey(),
+                'client_id' => $this->getClientId(),
+                'stripe_account' => $this->getStripeAccount(),
+                'stripe_version' => $this->getStripeVersion(),
+            ]);
+        }
+
+        return $this->stripeClient;
+    }
+
+    public function getClientId(): ?string
+    {
+        return $this->clientId;
+    }
+
+    public function getStripeAccount(): ?string
+    {
+        return $this->stripeAccount;
+    }
+
+    public function getStripeVersion(): string
+    {
+        return $this->stripeVersion;
+    }
+}

--- a/src/Api/StripeJsApi.php
+++ b/src/Api/StripeJsApi.php
@@ -6,5 +6,5 @@ namespace FluxSE\PayumStripe\Api;
 
 final class StripeJsApi implements StripeJsApiInterface
 {
-    use KeysAwareTrait;
+    use StripeClientAwareTrait;
 }

--- a/src/Api/StripeJsApiInterface.php
+++ b/src/Api/StripeJsApiInterface.php
@@ -4,6 +4,6 @@ declare(strict_types=1);
 
 namespace FluxSE\PayumStripe\Api;
 
-interface StripeJsApiInterface extends KeysAwareInterface
+interface StripeJsApiInterface extends StripeClientAwareInterface
 {
 }

--- a/src/Request/Api/Resource/AllPlan.php
+++ b/src/Request/Api/Resource/AllPlan.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FluxSE\PayumStripe\Request\Api\Resource;
+
+final class AllPlan extends AbstractAll
+{
+}

--- a/src/Request/Api/Resource/AllPrice.php
+++ b/src/Request/Api/Resource/AllPrice.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FluxSE\PayumStripe\Request\Api\Resource;
+
+final class AllPrice extends AbstractAll
+{
+}

--- a/src/Request/Api/Resource/AllProduct.php
+++ b/src/Request/Api/Resource/AllProduct.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FluxSE\PayumStripe\Request\Api\Resource;
+
+final class AllProduct extends AbstractAll
+{
+}

--- a/src/Request/Api/Resource/CreatePrice.php
+++ b/src/Request/Api/Resource/CreatePrice.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FluxSE\PayumStripe\Request\Api\Resource;
+
+final class CreatePrice extends AbstractCreate
+{
+}

--- a/src/Request/Api/Resource/CreateProduct.php
+++ b/src/Request/Api/Resource/CreateProduct.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FluxSE\PayumStripe\Request\Api\Resource;
+
+final class CreateProduct extends AbstractCreate
+{
+}

--- a/src/Request/Api/Resource/DeleteProduct.php
+++ b/src/Request/Api/Resource/DeleteProduct.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FluxSE\PayumStripe\Request\Api\Resource;
+
+final class DeleteProduct extends AbstractDelete
+{
+}

--- a/src/Request/Api/Resource/RetrievePrice.php
+++ b/src/Request/Api/Resource/RetrievePrice.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FluxSE\PayumStripe\Request\Api\Resource;
+
+final class RetrievePrice extends AbstractRetrieve
+{
+}

--- a/src/Request/Api/Resource/UpdatePlan.php
+++ b/src/Request/Api/Resource/UpdatePlan.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FluxSE\PayumStripe\Request\Api\Resource;
+
+final class UpdatePlan extends AbstractUpdate
+{
+}

--- a/src/Request/Api/Resource/UpdatePrice.php
+++ b/src/Request/Api/Resource/UpdatePrice.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FluxSE\PayumStripe\Request\Api\Resource;
+
+final class UpdatePrice extends AbstractUpdate
+{
+}

--- a/src/Request/Api/Resource/UpdateProduct.php
+++ b/src/Request/Api/Resource/UpdateProduct.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FluxSE\PayumStripe\Request\Api\Resource;
+
+final class UpdateProduct extends AbstractUpdate
+{
+}

--- a/src/StripeCheckoutSessionGatewayFactory.php
+++ b/src/StripeCheckoutSessionGatewayFactory.php
@@ -64,6 +64,9 @@ final class StripeCheckoutSessionGatewayFactory extends AbstractStripeGatewayFac
             $config['publishable_key'],
             $config['secret_key'],
             $config['webhook_secret_keys'],
+            $config['client_id'],
+            $config['stripe_account'],
+            $config['stripe_version'],
             $config['payment_method_types']
         );
     }

--- a/src/StripeJsGatewayFactory.php
+++ b/src/StripeJsGatewayFactory.php
@@ -10,6 +10,7 @@ use FluxSE\PayumStripe\Action\StripeJs\CaptureAction;
 use FluxSE\PayumStripe\Action\StripeJs\ConvertPaymentAction;
 use FluxSE\PayumStripe\Api\KeysAwareInterface;
 use FluxSE\PayumStripe\Api\StripeCheckoutSessionApi;
+use FluxSE\PayumStripe\Api\StripeJsApi;
 use Payum\Core\Bridge\Spl\ArrayObject;
 use Stripe\PaymentIntent;
 
@@ -42,10 +43,13 @@ final class StripeJsGatewayFactory extends AbstractStripeGatewayFactory
 
     protected function initApi(ArrayObject $config): KeysAwareInterface
     {
-        return new StripeCheckoutSessionApi(
+        return new StripeJsApi(
             $config['publishable_key'],
             $config['secret_key'],
-            $config['webhook_secret_keys']
+            $config['webhook_secret_keys'],
+            $config['client_id'],
+            $config['stripe_account'],
+            $config['stripe_version']
         );
     }
 }

--- a/tests/Action/Api/ApiAwareActionTestTrait.php
+++ b/tests/Action/Api/ApiAwareActionTestTrait.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace Tests\FluxSE\PayumStripe\Action\Api;
 
-use FluxSE\PayumStripe\Api\KeysAwareInterface;
+use FluxSE\PayumStripe\Api\StripeClientAwareInterface;
 use PHPUnit\Framework\MockObject\MockObject;
+use Stripe\Service\AbstractService;
+use Stripe\StripeClient;
 
 trait ApiAwareActionTestTrait
 {
@@ -21,25 +23,23 @@ trait ApiAwareActionTestTrait
     abstract protected function createMock(string $originalClassName): MockObject;
 
     /**
-     * @return MockObject&KeysAwareInterface
+     * @return MockObject&StripeClientAwareInterface
      */
-    protected function createApiMock(bool $shouldGetSecretKey = true): KeysAwareInterface
+    protected function createApiMock(): StripeClientAwareInterface
     {
+        $stripeClient = new StripeClient('sk_test_123');
         $apiMock = $this->createMock($this->getApiClass());
 
-        if ($shouldGetSecretKey) {
-            $apiMock
-                ->expects($this->atLeastOnce())
-                ->method('getSecretKey')
-                ->willReturn('sk_test_123')
-            ;
-        }
+        $apiMock
+            ->method('getStripeClient')
+            ->willReturn($stripeClient)
+        ;
 
         return $apiMock;
     }
 
     protected function getApiClass(): string
     {
-        return KeysAwareInterface::class;
+        return StripeClientAwareInterface::class;
     }
 }

--- a/tests/Action/Api/ResolveWebhookEventActionTest.php
+++ b/tests/Action/Api/ResolveWebhookEventActionTest.php
@@ -43,7 +43,7 @@ final class ResolveWebhookEventActionTest extends TestCase
             ->method('execute')
             ->with($this->isInstanceOf(GetHttpRequest::class));
 
-        $apiMock = $this->createApiMock(false);
+        $apiMock = $this->createApiMock();
 
         $action->setApiClass(KeysAwareInterface::class);
         $action->setGateway($gatewayMock);
@@ -81,7 +81,7 @@ final class ResolveWebhookEventActionTest extends TestCase
                 $this->throwException(SignatureVerificationException::factory(''))
             );
 
-        $apiMock = $this->createApiMock(false);
+        $apiMock = $this->createApiMock();
         $apiMock
             ->expects($this->once())
             ->method('getWebhookSecretKeys')
@@ -131,7 +131,7 @@ final class ResolveWebhookEventActionTest extends TestCase
                 })
             );
 
-        $apiMock = $this->createApiMock(false);
+        $apiMock = $this->createApiMock();
         $apiMock
             ->expects($this->once())
             ->method('getWebhookSecretKeys')
@@ -182,7 +182,7 @@ final class ResolveWebhookEventActionTest extends TestCase
                 })
             );
 
-        $apiMock = $this->createApiMock(false);
+        $apiMock = $this->createApiMock();
         $apiMock
             ->expects($this->once())
             ->method('getWebhookSecretKeys')
@@ -230,7 +230,7 @@ final class ResolveWebhookEventActionTest extends TestCase
                 })
             );
 
-        $apiMock = $this->createApiMock(false);
+        $apiMock = $this->createApiMock();
         $apiMock
             ->expects($this->once())
             ->method('getWebhookSecretKeys')

--- a/tests/Action/Api/Resource/AllActionTest.php
+++ b/tests/Action/Api/Resource/AllActionTest.php
@@ -39,6 +39,14 @@ use Stripe\Plan;
 use Stripe\Price;
 use Stripe\Product;
 use Stripe\Service\AbstractService;
+use Stripe\Service\Checkout\SessionService;
+use Stripe\Service\CouponService;
+use Stripe\Service\CustomerService;
+use Stripe\Service\InvoiceService;
+use Stripe\Service\PlanService;
+use Stripe\Service\PriceService;
+use Stripe\Service\ProductService;
+use Stripe\Service\TaxRateService;
 use Stripe\StripeClient;
 use Stripe\TaxRate;
 use Tests\FluxSE\PayumStripe\Action\Api\ApiAwareActionTestTrait;
@@ -70,9 +78,11 @@ final class AllActionTest extends TestCase
     public function testShouldAllAPaymentIntent(
         string $allActionClass,
         string $allRequestClass,
-        string $allClass
+        string $allClass,
+        string $serviceClass
     ): void {
         $apiMock = $this->createApiMock();
+        $stripeClient = $apiMock->getStripeClient();
 
         /** @var AbstractAllAction $action */
         $action = new $allActionClass();
@@ -115,6 +125,9 @@ final class AllActionTest extends TestCase
 
         $action->execute($request);
         $this->assertContainsOnlyInstancesOf($allClass, $request->getApiResources());
+
+        $service = $action->getStripeService($stripeClient);
+        $this->assertInstanceOf($serviceClass, $service);
     }
 
     public function testShouldThrowExceptionIfApiResourceClassIsNotCreatable(): void
@@ -148,14 +161,14 @@ final class AllActionTest extends TestCase
     public function requestList(): array
     {
         return [
-            [AllCouponAction::class, AllCoupon::class, Coupon::class],
-            [AllCustomerAction::class, AllCustomer::class, Customer::class],
-            [AllInvoiceAction::class, AllInvoice::class, Invoice::class],
-            [AllPlanAction::class, AllPlan::class, Plan::class],
-            [AllPriceAction::class, AllPrice::class, Price::class],
-            [AllProductAction::class, AllProduct::class, Product::class],
-            [AllTaxRateAction::class, AllTaxRate::class, TaxRate::class],
-            [AllSessionAction::class, AllSession::class, Session::class],
+            [AllCouponAction::class, AllCoupon::class, Coupon::class, CouponService::class],
+            [AllCustomerAction::class, AllCustomer::class, Customer::class, CustomerService::class],
+            [AllInvoiceAction::class, AllInvoice::class, Invoice::class, InvoiceService::class],
+            [AllPlanAction::class, AllPlan::class, Plan::class, PlanService::class],
+            [AllPriceAction::class, AllPrice::class, Price::class, PriceService::class],
+            [AllProductAction::class, AllProduct::class, Product::class, ProductService::class],
+            [AllTaxRateAction::class, AllTaxRate::class, TaxRate::class, TaxRateService::class],
+            [AllSessionAction::class, AllSession::class, Session::class, SessionService::class],
         ];
     }
 }

--- a/tests/Action/Api/Resource/AllActionTest.php
+++ b/tests/Action/Api/Resource/AllActionTest.php
@@ -8,6 +8,9 @@ use FluxSE\PayumStripe\Action\Api\Resource\AbstractAllAction;
 use FluxSE\PayumStripe\Action\Api\Resource\AllCouponAction;
 use FluxSE\PayumStripe\Action\Api\Resource\AllCustomerAction;
 use FluxSE\PayumStripe\Action\Api\Resource\AllInvoiceAction;
+use FluxSE\PayumStripe\Action\Api\Resource\AllPlanAction;
+use FluxSE\PayumStripe\Action\Api\Resource\AllPriceAction;
+use FluxSE\PayumStripe\Action\Api\Resource\AllProductAction;
 use FluxSE\PayumStripe\Action\Api\Resource\AllResourceActionInterface;
 use FluxSE\PayumStripe\Action\Api\Resource\AllSessionAction;
 use FluxSE\PayumStripe\Action\Api\Resource\AllTaxRateAction;
@@ -17,6 +20,9 @@ use FluxSE\PayumStripe\Request\Api\Resource\AllCoupon;
 use FluxSE\PayumStripe\Request\Api\Resource\AllCustomer;
 use FluxSE\PayumStripe\Request\Api\Resource\AllInterface;
 use FluxSE\PayumStripe\Request\Api\Resource\AllInvoice;
+use FluxSE\PayumStripe\Request\Api\Resource\AllPlan;
+use FluxSE\PayumStripe\Request\Api\Resource\AllPrice;
+use FluxSE\PayumStripe\Request\Api\Resource\AllProduct;
 use FluxSE\PayumStripe\Request\Api\Resource\AllSession;
 use FluxSE\PayumStripe\Request\Api\Resource\AllTaxRate;
 use LogicException;
@@ -29,6 +35,9 @@ use Stripe\Checkout\Session;
 use Stripe\Coupon;
 use Stripe\Customer;
 use Stripe\Invoice;
+use Stripe\Plan;
+use Stripe\Price;
+use Stripe\Product;
 use Stripe\Service\AbstractService;
 use Stripe\StripeClient;
 use Stripe\TaxRate;
@@ -142,6 +151,9 @@ final class AllActionTest extends TestCase
             [AllCouponAction::class, AllCoupon::class, Coupon::class],
             [AllCustomerAction::class, AllCustomer::class, Customer::class],
             [AllInvoiceAction::class, AllInvoice::class, Invoice::class],
+            [AllPlanAction::class, AllPlan::class, Plan::class],
+            [AllPriceAction::class, AllPrice::class, Price::class],
+            [AllProductAction::class, AllProduct::class, Product::class],
             [AllTaxRateAction::class, AllTaxRate::class, TaxRate::class],
             [AllSessionAction::class, AllSession::class, Session::class],
         ];

--- a/tests/Action/Api/Resource/AllActionTest.php
+++ b/tests/Action/Api/Resource/AllActionTest.php
@@ -29,7 +29,8 @@ use Stripe\Checkout\Session;
 use Stripe\Coupon;
 use Stripe\Customer;
 use Stripe\Invoice;
-use Stripe\Issuing\CardDetails;
+use Stripe\Service\AbstractService;
+use Stripe\StripeClient;
 use Stripe\TaxRate;
 use Tests\FluxSE\PayumStripe\Action\Api\ApiAwareActionTestTrait;
 use Tests\FluxSE\PayumStripe\Stripe\StripeApiTestHelper;
@@ -68,7 +69,6 @@ final class AllActionTest extends TestCase
         $action = new $allActionClass();
         $action->setApiClass(KeysAwareInterface::class);
         $action->setApi($apiMock);
-        $this->assertEquals($allClass, $action->getApiResourceClass());
 
         /** @var AbstractAll $request */
         $request = new $allRequestClass();
@@ -115,10 +115,13 @@ final class AllActionTest extends TestCase
             {
                 return true;
             }
-        };
 
-        $action->setApiResourceClass(CardDetails::class);
-        $this->assertEquals(CardDetails::class, $action->getApiResourceClass());
+            public function getStripeService(StripeClient $stripeClient): AbstractService
+            {
+                return new class($stripeClient) extends AbstractService {
+                };
+            }
+        };
 
         $request = new class() extends AbstractAll {
         };

--- a/tests/Action/Api/Resource/CreateActionTest.php
+++ b/tests/Action/Api/Resource/CreateActionTest.php
@@ -48,6 +48,18 @@ use Stripe\Price;
 use Stripe\Product;
 use Stripe\Refund;
 use Stripe\Service\AbstractService;
+use Stripe\Service\Checkout\SessionService;
+use Stripe\Service\CouponService;
+use Stripe\Service\CustomerService;
+use Stripe\Service\PaymentIntentService;
+use Stripe\Service\PaymentMethodService;
+use Stripe\Service\PlanService;
+use Stripe\Service\PriceService;
+use Stripe\Service\ProductService;
+use Stripe\Service\RefundService;
+use Stripe\Service\SetupIntentService;
+use Stripe\Service\SubscriptionService;
+use Stripe\Service\TaxRateService;
 use Stripe\SetupIntent;
 use Stripe\StripeClient;
 use Stripe\Subscription;
@@ -81,11 +93,13 @@ final class CreateActionTest extends TestCase
     public function testShouldCreateAnApiRessource(
         string $createActionClass,
         string $createRequestClass,
-        string $createClass
+        string $createClass,
+        string $serviceClass
     ): void {
         $model = [];
 
         $apiMock = $this->createApiMock();
+        $stripeClient = $apiMock->getStripeClient();
 
         /** @var AbstractCreateAction $action */
         $action = new $createActionClass();
@@ -116,6 +130,9 @@ final class CreateActionTest extends TestCase
 
         $action->execute($request);
         $this->assertInstanceOf($createClass, $request->getApiResource());
+
+        $service = $action->getStripeService($stripeClient);
+        $this->assertInstanceOf($serviceClass, $service);
     }
 
     public function testShouldThrowExceptionIfApiResourceClassIsNotCreatable(): void
@@ -145,18 +162,18 @@ final class CreateActionTest extends TestCase
     public function requestList(): array
     {
         return [
-            [CreateCouponAction::class, CreateCoupon::class, Coupon::class],
-            [CreateCustomerAction::class, CreateCustomer::class, Customer::class],
-            [CreateSessionAction::class, CreateSession::class, Session::class],
-            [CreatePaymentIntentAction::class, CreatePaymentIntent::class, PaymentIntent::class],
-            [CreatePaymentMethodAction::class, CreatePaymentMethod::class, PaymentMethod::class],
-            [CreatePlanAction::class, CreatePlan::class, Plan::class],
-            [CreatePriceAction::class, CreatePrice::class, Price::class],
-            [CreateProductAction::class, CreateProduct::class, Product::class],
-            [CreateRefundAction::class, CreateRefund::class, Refund::class],
-            [CreateSetupIntentAction::class, CreateSetupIntent::class, SetupIntent::class],
-            [CreateSubscriptionAction::class, CreateSubscription::class, Subscription::class],
-            [CreateTaxRateAction::class, CreateTaxRate::class, TaxRate::class],
+            [CreateCouponAction::class, CreateCoupon::class, Coupon::class, CouponService::class],
+            [CreateCustomerAction::class, CreateCustomer::class, Customer::class, CustomerService::class],
+            [CreateSessionAction::class, CreateSession::class, Session::class, SessionService::class],
+            [CreatePaymentIntentAction::class, CreatePaymentIntent::class, PaymentIntent::class, PaymentIntentService::class],
+            [CreatePaymentMethodAction::class, CreatePaymentMethod::class, PaymentMethod::class, PaymentMethodService::class],
+            [CreatePlanAction::class, CreatePlan::class, Plan::class, PlanService::class],
+            [CreatePriceAction::class, CreatePrice::class, Price::class, PriceService::class],
+            [CreateProductAction::class, CreateProduct::class, Product::class, ProductService::class],
+            [CreateRefundAction::class, CreateRefund::class, Refund::class, RefundService::class],
+            [CreateSetupIntentAction::class, CreateSetupIntent::class, SetupIntent::class, SetupIntentService::class],
+            [CreateSubscriptionAction::class, CreateSubscription::class, Subscription::class, SubscriptionService::class],
+            [CreateTaxRateAction::class, CreateTaxRate::class, TaxRate::class, TaxRateService::class],
         ];
     }
 }

--- a/tests/Action/Api/Resource/CreateActionTest.php
+++ b/tests/Action/Api/Resource/CreateActionTest.php
@@ -8,6 +8,8 @@ use FluxSE\PayumStripe\Action\Api\Resource\CreateCustomerAction;
 use FluxSE\PayumStripe\Action\Api\Resource\CreatePaymentIntentAction;
 use FluxSE\PayumStripe\Action\Api\Resource\CreatePaymentMethodAction;
 use FluxSE\PayumStripe\Action\Api\Resource\CreatePlanAction;
+use FluxSE\PayumStripe\Action\Api\Resource\CreatePriceAction;
+use FluxSE\PayumStripe\Action\Api\Resource\CreateProductAction;
 use FluxSE\PayumStripe\Action\Api\Resource\CreateRefundAction;
 use FluxSE\PayumStripe\Action\Api\Resource\CreateResourceActionInterface;
 use FluxSE\PayumStripe\Action\Api\Resource\CreateSessionAction;
@@ -22,6 +24,8 @@ use FluxSE\PayumStripe\Request\Api\Resource\CreateInterface;
 use FluxSE\PayumStripe\Request\Api\Resource\CreatePaymentIntent;
 use FluxSE\PayumStripe\Request\Api\Resource\CreatePaymentMethod;
 use FluxSE\PayumStripe\Request\Api\Resource\CreatePlan;
+use FluxSE\PayumStripe\Request\Api\Resource\CreatePrice;
+use FluxSE\PayumStripe\Request\Api\Resource\CreateProduct;
 use FluxSE\PayumStripe\Request\Api\Resource\CreateRefund;
 use FluxSE\PayumStripe\Request\Api\Resource\CreateSession;
 use FluxSE\PayumStripe\Request\Api\Resource\CreateSetupIntent;
@@ -40,6 +44,8 @@ use Stripe\Issuing\CardDetails;
 use Stripe\PaymentIntent;
 use Stripe\PaymentMethod;
 use Stripe\Plan;
+use Stripe\Price;
+use Stripe\Product;
 use Stripe\Refund;
 use Stripe\Service\AbstractService;
 use Stripe\SetupIntent;
@@ -145,6 +151,8 @@ final class CreateActionTest extends TestCase
             [CreatePaymentIntentAction::class, CreatePaymentIntent::class, PaymentIntent::class],
             [CreatePaymentMethodAction::class, CreatePaymentMethod::class, PaymentMethod::class],
             [CreatePlanAction::class, CreatePlan::class, Plan::class],
+            [CreatePriceAction::class, CreatePrice::class, Price::class],
+            [CreateProductAction::class, CreateProduct::class, Product::class],
             [CreateRefundAction::class, CreateRefund::class, Refund::class],
             [CreateSetupIntentAction::class, CreateSetupIntent::class, SetupIntent::class],
             [CreateSubscriptionAction::class, CreateSubscription::class, Subscription::class],

--- a/tests/Action/Api/Resource/CreateActionTest.php
+++ b/tests/Action/Api/Resource/CreateActionTest.php
@@ -41,7 +41,9 @@ use Stripe\PaymentIntent;
 use Stripe\PaymentMethod;
 use Stripe\Plan;
 use Stripe\Refund;
+use Stripe\Service\AbstractService;
 use Stripe\SetupIntent;
+use Stripe\StripeClient;
 use Stripe\Subscription;
 use Stripe\TaxRate;
 use Tests\FluxSE\PayumStripe\Action\Api\ApiAwareActionTestTrait;
@@ -82,7 +84,6 @@ final class CreateActionTest extends TestCase
         /** @var AbstractCreateAction $action */
         $action = new $createActionClass();
         $action->setApiClass(KeysAwareInterface::class);
-        $this->assertEquals($createClass, $action->getApiResourceClass());
         $action->setApi($apiMock);
 
         /** @var AbstractCreate $request */
@@ -119,10 +120,13 @@ final class CreateActionTest extends TestCase
             {
                 return true;
             }
-        };
 
-        $action->setApiResourceClass(CardDetails::class);
-        $this->assertEquals(CardDetails::class, $action->getApiResourceClass());
+            public function getStripeService(StripeClient $stripeClient): AbstractService
+            {
+                return new class() extends AbstractService {
+                };
+            }
+        };
 
         $request = new class($model) extends AbstractCreate {
         };

--- a/tests/Action/Api/Resource/CustomCallActionTest.php
+++ b/tests/Action/Api/Resource/CustomCallActionTest.php
@@ -71,7 +71,6 @@ final class CustomCallActionTest extends TestCase
         $action = new $customCallActionClass();
         $action->setApiClass(KeysAwareInterface::class);
         $action->setApi($apiMock);
-        $this->assertEquals($customCallClass, $action->getApiResourceClass());
 
         /** @var AbstractCustomCall $request */
         $request = new $customCallRequestClass($id);

--- a/tests/Action/Api/Resource/DeleteActionTest.php
+++ b/tests/Action/Api/Resource/DeleteActionTest.php
@@ -26,6 +26,9 @@ use Stripe\Issuing\CardDetails;
 use Stripe\Plan;
 use Stripe\Product;
 use Stripe\Service\AbstractService;
+use Stripe\Service\CouponService;
+use Stripe\Service\PlanService;
+use Stripe\Service\ProductService;
 use Stripe\Stripe;
 use Stripe\StripeClient;
 use Tests\FluxSE\PayumStripe\Action\Api\ApiAwareActionTestTrait;
@@ -57,11 +60,13 @@ final class DeleteActionTest extends TestCase
     public function testShouldBeDeleted(
         string $deleteActionClass,
         string $deleteRequestClass,
-        string $deleteClass
+        string $deleteClass,
+        string $serviceClass
     ): void {
         $id = 'pi_1';
 
         $apiMock = $this->createApiMock();
+        $stripeClient = $apiMock->getStripeClient();
 
         /** @var AbstractDeleteAction $action */
         $action = new $deleteActionClass();
@@ -115,6 +120,9 @@ final class DeleteActionTest extends TestCase
 
         $action->execute($request);
         $this->assertInstanceOf($deleteClass, $request->getApiResource());
+
+        $service = $action->getStripeService($stripeClient);
+        $this->assertInstanceOf($serviceClass, $service);
     }
 
     /**
@@ -155,9 +163,9 @@ final class DeleteActionTest extends TestCase
     public function requestList(): array
     {
         return [
-            [DeleteCouponAction::class, DeleteCoupon::class, Coupon::class],
-            [DeletePlanAction::class, DeletePlan::class, Plan::class],
-            [DeleteProductAction::class, DeleteProduct::class, Product::class],
+            [DeleteCouponAction::class, DeleteCoupon::class, Coupon::class, CouponService::class],
+            [DeletePlanAction::class, DeletePlan::class, Plan::class, PlanService::class],
+            [DeleteProductAction::class, DeleteProduct::class, Product::class, ProductService::class],
         ];
     }
 }

--- a/tests/Action/Api/Resource/DeleteActionTest.php
+++ b/tests/Action/Api/Resource/DeleteActionTest.php
@@ -22,7 +22,9 @@ use Stripe\Coupon;
 use Stripe\Issuing\Card;
 use Stripe\Issuing\CardDetails;
 use Stripe\Plan;
+use Stripe\Service\AbstractService;
 use Stripe\Stripe;
+use Stripe\StripeClient;
 use Tests\FluxSE\PayumStripe\Action\Api\ApiAwareActionTestTrait;
 use Tests\FluxSE\PayumStripe\Stripe\StripeApiTestHelper;
 
@@ -62,7 +64,6 @@ final class DeleteActionTest extends TestCase
         $action = new $deleteActionClass();
         $action->setApiClass(KeysAwareInterface::class);
         $action->setApi($apiMock);
-        $this->assertEquals($deleteClass, $action->getApiResourceClass());
 
         /** @var AbstractDelete $request */
         $request = new $deleteRequestClass($id);
@@ -124,10 +125,13 @@ final class DeleteActionTest extends TestCase
             {
                 return true;
             }
-        };
 
-        $action->setApiResourceClass($faultClass);
-        $this->assertEquals($faultClass, $action->getApiResourceClass());
+            public function getStripeService(StripeClient $stripeClient): AbstractService
+            {
+                return new class() extends AbstractService {
+                };
+            }
+        };
 
         $request = new class($id) extends AbstractDelete {
         };

--- a/tests/Action/Api/Resource/DeleteActionTest.php
+++ b/tests/Action/Api/Resource/DeleteActionTest.php
@@ -5,12 +5,14 @@ namespace Tests\FluxSE\PayumStripe\Action\Api\Resource;
 use FluxSE\PayumStripe\Action\Api\Resource\AbstractDeleteAction;
 use FluxSE\PayumStripe\Action\Api\Resource\DeleteCouponAction;
 use FluxSE\PayumStripe\Action\Api\Resource\DeletePlanAction;
+use FluxSE\PayumStripe\Action\Api\Resource\DeleteProductAction;
 use FluxSE\PayumStripe\Action\Api\Resource\DeleteResourceActionInterface;
 use FluxSE\PayumStripe\Api\KeysAwareInterface;
 use FluxSE\PayumStripe\Request\Api\Resource\AbstractDelete;
 use FluxSE\PayumStripe\Request\Api\Resource\DeleteCoupon;
 use FluxSE\PayumStripe\Request\Api\Resource\DeleteInterface;
 use FluxSE\PayumStripe\Request\Api\Resource\DeletePlan;
+use FluxSE\PayumStripe\Request\Api\Resource\DeleteProduct;
 use LogicException;
 use Payum\Core\Action\ActionInterface;
 use Payum\Core\ApiAwareInterface;
@@ -22,6 +24,7 @@ use Stripe\Coupon;
 use Stripe\Issuing\Card;
 use Stripe\Issuing\CardDetails;
 use Stripe\Plan;
+use Stripe\Product;
 use Stripe\Service\AbstractService;
 use Stripe\Stripe;
 use Stripe\StripeClient;
@@ -154,6 +157,7 @@ final class DeleteActionTest extends TestCase
         return [
             [DeleteCouponAction::class, DeleteCoupon::class, Coupon::class],
             [DeletePlanAction::class, DeletePlan::class, Plan::class],
+            [DeleteProductAction::class, DeleteProduct::class, Product::class],
         ];
     }
 }

--- a/tests/Action/Api/Resource/RetrieveActionTest.php
+++ b/tests/Action/Api/Resource/RetrieveActionTest.php
@@ -49,6 +49,18 @@ use Stripe\Plan;
 use Stripe\Price;
 use Stripe\Product;
 use Stripe\Service\AbstractService;
+use Stripe\Service\ChargeService;
+use Stripe\Service\Checkout\SessionService;
+use Stripe\Service\CouponService;
+use Stripe\Service\CustomerService;
+use Stripe\Service\InvoiceService;
+use Stripe\Service\PaymentIntentService;
+use Stripe\Service\PaymentMethodService;
+use Stripe\Service\PlanService;
+use Stripe\Service\PriceService;
+use Stripe\Service\ProductService;
+use Stripe\Service\SetupIntentService;
+use Stripe\Service\SubscriptionService;
 use Stripe\SetupIntent;
 use Stripe\StripeClient;
 use Stripe\Subscription;
@@ -81,11 +93,13 @@ final class RetrieveActionTest extends TestCase
     public function testShouldBeRetrieved(
         string $retrieveActionClass,
         string $retrieveRequestClass,
-        string $retrieveClass
+        string $retrieveClass,
+        string $serviceClass
     ): void {
         $id = 'pi_1';
 
         $apiMock = $this->createApiMock();
+        $stripeClient = $apiMock->getStripeClient();
 
         /** @var AbstractRetrieveAction $action */
         $action = new $retrieveActionClass();
@@ -116,6 +130,9 @@ final class RetrieveActionTest extends TestCase
 
         $action->execute($request);
         $this->assertInstanceOf($retrieveClass, $request->getApiResource());
+
+        $service = $action->getStripeService($stripeClient);
+        $this->assertInstanceOf($serviceClass, $service);
     }
 
     public function testShouldThrowExceptionIfApiResourceClassIsNotCreatable(): void
@@ -150,18 +167,18 @@ final class RetrieveActionTest extends TestCase
     public function requestList(): array
     {
         return [
-            [RetrieveChargeAction::class, RetrieveCharge::class, Charge::class],
-            [RetrieveCouponAction::class, RetrieveCoupon::class, Coupon::class],
-            [RetrieveCustomerAction::class, RetrieveCustomer::class, Customer::class],
-            [RetrieveInvoiceAction::class, RetrieveInvoice::class, Invoice::class],
-            [RetrievePaymentIntentAction::class, RetrievePaymentIntent::class, PaymentIntent::class],
-            [RetrievePaymentMethodAction::class, RetrievePaymentMethod::class, PaymentMethod::class],
-            [RetrievePlanAction::class, RetrievePlan::class, Plan::class],
-            [RetrievePriceAction::class, RetrievePrice::class, Price::class],
-            [RetrieveProductAction::class, RetrieveProduct::class, Product::class],
-            [RetrieveSessionAction::class, RetrieveSession::class, Session::class],
-            [RetrieveSetupIntentAction::class, RetrieveSetupIntent::class, SetupIntent::class],
-            [RetrieveSubscriptionAction::class, RetrieveSubscription::class, Subscription::class],
+            [RetrieveChargeAction::class, RetrieveCharge::class, Charge::class, ChargeService::class],
+            [RetrieveCouponAction::class, RetrieveCoupon::class, Coupon::class, CouponService::class],
+            [RetrieveCustomerAction::class, RetrieveCustomer::class, Customer::class, CustomerService::class],
+            [RetrieveInvoiceAction::class, RetrieveInvoice::class, Invoice::class, InvoiceService::class],
+            [RetrievePaymentIntentAction::class, RetrievePaymentIntent::class, PaymentIntent::class, PaymentIntentService::class],
+            [RetrievePaymentMethodAction::class, RetrievePaymentMethod::class, PaymentMethod::class, PaymentMethodService::class],
+            [RetrievePlanAction::class, RetrievePlan::class, Plan::class, PlanService::class],
+            [RetrievePriceAction::class, RetrievePrice::class, Price::class, PriceService::class],
+            [RetrieveProductAction::class, RetrieveProduct::class, Product::class, ProductService::class],
+            [RetrieveSessionAction::class, RetrieveSession::class, Session::class, SessionService::class],
+            [RetrieveSetupIntentAction::class, RetrieveSetupIntent::class, SetupIntent::class, SetupIntentService::class],
+            [RetrieveSubscriptionAction::class, RetrieveSubscription::class, Subscription::class, SubscriptionService::class],
         ];
     }
 }

--- a/tests/Action/Api/Resource/RetrieveActionTest.php
+++ b/tests/Action/Api/Resource/RetrieveActionTest.php
@@ -10,6 +10,7 @@ use FluxSE\PayumStripe\Action\Api\Resource\RetrieveInvoiceAction;
 use FluxSE\PayumStripe\Action\Api\Resource\RetrievePaymentIntentAction;
 use FluxSE\PayumStripe\Action\Api\Resource\RetrievePaymentMethodAction;
 use FluxSE\PayumStripe\Action\Api\Resource\RetrievePlanAction;
+use FluxSE\PayumStripe\Action\Api\Resource\RetrievePriceAction;
 use FluxSE\PayumStripe\Action\Api\Resource\RetrieveProductAction;
 use FluxSE\PayumStripe\Action\Api\Resource\RetrieveResourceActionInterface;
 use FluxSE\PayumStripe\Action\Api\Resource\RetrieveSessionAction;
@@ -25,6 +26,7 @@ use FluxSE\PayumStripe\Request\Api\Resource\RetrieveInvoice;
 use FluxSE\PayumStripe\Request\Api\Resource\RetrievePaymentIntent;
 use FluxSE\PayumStripe\Request\Api\Resource\RetrievePaymentMethod;
 use FluxSE\PayumStripe\Request\Api\Resource\RetrievePlan;
+use FluxSE\PayumStripe\Request\Api\Resource\RetrievePrice;
 use FluxSE\PayumStripe\Request\Api\Resource\RetrieveProduct;
 use FluxSE\PayumStripe\Request\Api\Resource\RetrieveSession;
 use FluxSE\PayumStripe\Request\Api\Resource\RetrieveSetupIntent;
@@ -44,6 +46,7 @@ use Stripe\Issuing\CardDetails;
 use Stripe\PaymentIntent;
 use Stripe\PaymentMethod;
 use Stripe\Plan;
+use Stripe\Price;
 use Stripe\Product;
 use Stripe\Service\AbstractService;
 use Stripe\SetupIntent;
@@ -154,6 +157,7 @@ final class RetrieveActionTest extends TestCase
             [RetrievePaymentIntentAction::class, RetrievePaymentIntent::class, PaymentIntent::class],
             [RetrievePaymentMethodAction::class, RetrievePaymentMethod::class, PaymentMethod::class],
             [RetrievePlanAction::class, RetrievePlan::class, Plan::class],
+            [RetrievePriceAction::class, RetrievePrice::class, Price::class],
             [RetrieveProductAction::class, RetrieveProduct::class, Product::class],
             [RetrieveSessionAction::class, RetrieveSession::class, Session::class],
             [RetrieveSetupIntentAction::class, RetrieveSetupIntent::class, SetupIntent::class],

--- a/tests/Action/Api/Resource/RetrieveActionTest.php
+++ b/tests/Action/Api/Resource/RetrieveActionTest.php
@@ -45,7 +45,9 @@ use Stripe\PaymentIntent;
 use Stripe\PaymentMethod;
 use Stripe\Plan;
 use Stripe\Product;
+use Stripe\Service\AbstractService;
 use Stripe\SetupIntent;
+use Stripe\StripeClient;
 use Stripe\Subscription;
 use Tests\FluxSE\PayumStripe\Action\Api\ApiAwareActionTestTrait;
 use Tests\FluxSE\PayumStripe\Stripe\StripeApiTestHelper;
@@ -86,7 +88,6 @@ final class RetrieveActionTest extends TestCase
         $action = new $retrieveActionClass();
         $action->setApiClass(KeysAwareInterface::class);
         $action->setApi($apiMock);
-        $this->assertEquals($retrieveClass, $action->getApiResourceClass());
 
         /** @var AbstractRetrieve $request */
         $request = new $retrieveRequestClass($id);
@@ -122,10 +123,13 @@ final class RetrieveActionTest extends TestCase
             {
                 return true;
             }
-        };
 
-        $action->setApiResourceClass(CardDetails::class);
-        $this->assertEquals(CardDetails::class, $action->getApiResourceClass());
+            public function getStripeService(StripeClient $stripeClient): AbstractService
+            {
+                return new class() extends AbstractService {
+                };
+            }
+        };
 
         $request = new class($id) extends AbstractRetrieve {
         };

--- a/tests/Action/Api/Resource/UpdateActionTest.php
+++ b/tests/Action/Api/Resource/UpdateActionTest.php
@@ -32,6 +32,12 @@ use Stripe\Plan;
 use Stripe\Price;
 use Stripe\Product;
 use Stripe\Service\AbstractService;
+use Stripe\Service\CouponService;
+use Stripe\Service\PaymentIntentService;
+use Stripe\Service\PlanService;
+use Stripe\Service\PriceService;
+use Stripe\Service\ProductService;
+use Stripe\Service\SubscriptionService;
 use Stripe\StripeClient;
 use Stripe\Subscription;
 use Tests\FluxSE\PayumStripe\Action\Api\ApiAwareActionTestTrait;
@@ -63,12 +69,14 @@ final class UpdateActionTest extends TestCase
     public function testShouldUpdateAPaymentIntent(
         string $updateActionClass,
         string $updateRequestClass,
-        string $updateClass
+        string $updateClass,
+        string $serviceClass
     ): void {
         $id = 'pi_1';
         $parameters = [];
 
         $apiMock = $this->createApiMock();
+        $stripeClient = $apiMock->getStripeClient();
 
         /** @var AbstractUpdateAction $action */
         $action = new $updateActionClass();
@@ -99,6 +107,9 @@ final class UpdateActionTest extends TestCase
 
         $action->execute($request);
         $this->assertInstanceOf($updateClass, $request->getApiResource());
+
+        $service = $action->getStripeService($stripeClient);
+        $this->assertInstanceOf($serviceClass, $service);
     }
 
     public function testShouldThrowExceptionIfApiResourceClassIsNotCreatable(): void
@@ -134,12 +145,12 @@ final class UpdateActionTest extends TestCase
     public function requestList(): array
     {
         return [
-            [UpdateCouponAction::class, UpdateCoupon::class, Coupon::class],
-            [UpdatePaymentIntentAction::class, UpdatePaymentIntent::class, PaymentIntent::class],
-            [UpdatePlanAction::class, UpdatePlan::class, Plan::class],
-            [UpdatePriceAction::class, UpdatePrice::class, Price::class],
-            [UpdateProductAction::class, UpdateProduct::class, Product::class],
-            [UpdateSubscriptionAction::class, UpdateSubscription::class, Subscription::class],
+            [UpdateCouponAction::class, UpdateCoupon::class, Coupon::class, CouponService::class],
+            [UpdatePaymentIntentAction::class, UpdatePaymentIntent::class, PaymentIntent::class, PaymentIntentService::class],
+            [UpdatePlanAction::class, UpdatePlan::class, Plan::class, PlanService::class],
+            [UpdatePriceAction::class, UpdatePrice::class, Price::class, PriceService::class],
+            [UpdateProductAction::class, UpdateProduct::class, Product::class, ProductService::class],
+            [UpdateSubscriptionAction::class, UpdateSubscription::class, Subscription::class, SubscriptionService::class],
         ];
     }
 }

--- a/tests/Action/Api/Resource/UpdateActionTest.php
+++ b/tests/Action/Api/Resource/UpdateActionTest.php
@@ -22,6 +22,8 @@ use Stripe\ApiResource;
 use Stripe\Coupon;
 use Stripe\Issuing\CardDetails;
 use Stripe\PaymentIntent;
+use Stripe\Service\AbstractService;
+use Stripe\StripeClient;
 use Stripe\Subscription;
 use Tests\FluxSE\PayumStripe\Action\Api\ApiAwareActionTestTrait;
 use Tests\FluxSE\PayumStripe\Stripe\StripeApiTestHelper;
@@ -63,7 +65,6 @@ final class UpdateActionTest extends TestCase
         $action = new $updateActionClass();
         $action->setApiClass(KeysAwareInterface::class);
         $action->setApi($apiMock);
-        $this->assertEquals($updateClass, $action->getApiResourceClass());
 
         /** @var AbstractUpdate $request */
         $request = new $updateRequestClass($id, $parameters);
@@ -100,10 +101,13 @@ final class UpdateActionTest extends TestCase
             {
                 return true;
             }
-        };
 
-        $action->setApiResourceClass(CardDetails::class);
-        $this->assertEquals(CardDetails::class, $action->getApiResourceClass());
+            public function getStripeService(StripeClient $stripeClient): AbstractService
+            {
+                return new class() extends AbstractService {
+                };
+            }
+        };
 
         $request = new class($id, $parameters) extends AbstractUpdate {
         };

--- a/tests/Action/Api/Resource/UpdateActionTest.php
+++ b/tests/Action/Api/Resource/UpdateActionTest.php
@@ -5,6 +5,9 @@ namespace Tests\FluxSE\PayumStripe\Action\Api\Resource;
 use FluxSE\PayumStripe\Action\Api\Resource\AbstractUpdateAction;
 use FluxSE\PayumStripe\Action\Api\Resource\UpdateCouponAction;
 use FluxSE\PayumStripe\Action\Api\Resource\UpdatePaymentIntentAction;
+use FluxSE\PayumStripe\Action\Api\Resource\UpdatePlanAction;
+use FluxSE\PayumStripe\Action\Api\Resource\UpdatePriceAction;
+use FluxSE\PayumStripe\Action\Api\Resource\UpdateProductAction;
 use FluxSE\PayumStripe\Action\Api\Resource\UpdateResourceActionInterface;
 use FluxSE\PayumStripe\Action\Api\Resource\UpdateSubscriptionAction;
 use FluxSE\PayumStripe\Api\KeysAwareInterface;
@@ -12,6 +15,9 @@ use FluxSE\PayumStripe\Request\Api\Resource\AbstractUpdate;
 use FluxSE\PayumStripe\Request\Api\Resource\UpdateCoupon;
 use FluxSE\PayumStripe\Request\Api\Resource\UpdateInterface;
 use FluxSE\PayumStripe\Request\Api\Resource\UpdatePaymentIntent;
+use FluxSE\PayumStripe\Request\Api\Resource\UpdatePlan;
+use FluxSE\PayumStripe\Request\Api\Resource\UpdatePrice;
+use FluxSE\PayumStripe\Request\Api\Resource\UpdateProduct;
 use FluxSE\PayumStripe\Request\Api\Resource\UpdateSubscription;
 use LogicException;
 use Payum\Core\Action\ActionInterface;
@@ -22,6 +28,9 @@ use Stripe\ApiResource;
 use Stripe\Coupon;
 use Stripe\Issuing\CardDetails;
 use Stripe\PaymentIntent;
+use Stripe\Plan;
+use Stripe\Price;
+use Stripe\Product;
 use Stripe\Service\AbstractService;
 use Stripe\StripeClient;
 use Stripe\Subscription;
@@ -127,6 +136,9 @@ final class UpdateActionTest extends TestCase
         return [
             [UpdateCouponAction::class, UpdateCoupon::class, Coupon::class],
             [UpdatePaymentIntentAction::class, UpdatePaymentIntent::class, PaymentIntent::class],
+            [UpdatePlanAction::class, UpdatePlan::class, Plan::class],
+            [UpdatePriceAction::class, UpdatePrice::class, Price::class],
+            [UpdateProductAction::class, UpdateProduct::class, Product::class],
             [UpdateSubscriptionAction::class, UpdateSubscription::class, Subscription::class],
         ];
     }

--- a/tests/Action/Api/StripeApiAwareTraitTest.php
+++ b/tests/Action/Api/StripeApiAwareTraitTest.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Tests\FluxSE\PayumStripe\Action\Api;
 
 use FluxSE\PayumStripe\Action\Api\StripeApiAwareTrait;
-use FluxSE\PayumStripe\Api\KeysAwareInterface;
-use FluxSE\PayumStripe\Api\KeysAwareTrait;
+use FluxSE\PayumStripe\Api\StripeClientAwareInterface;
+use FluxSE\PayumStripe\Api\StripeClientAwareTrait;
 use PHPUnit\Framework\TestCase;
 
 final class StripeApiAwareTraitTest extends TestCase
@@ -14,13 +14,13 @@ final class StripeApiAwareTraitTest extends TestCase
     public function testShouldGetApiClass(): void
     {
         $trait = $this->getObjectForTrait(StripeApiAwareTrait::class);
-        $this->assertEquals(KeysAwareInterface::class, $trait->getApiClass());
+        $this->assertEquals(StripeClientAwareInterface::class, $trait->getApiClass());
     }
 
     public function testShouldSetApiClass(): void
     {
         $trait = $this->getObjectForTrait(StripeApiAwareTrait::class);
-        $trait->setApiClass(KeysAwareTrait::class);
-        $this->assertEquals(KeysAwareTrait::class, $trait->getApiClass());
+        $trait->setApiClass(StripeClientAwareTrait::class);
+        $this->assertEquals(StripeClientAwareTrait::class, $trait->getApiClass());
     }
 }

--- a/tests/Action/StripeCheckoutSession/ConvertPaymentActionTest.php
+++ b/tests/Action/StripeCheckoutSession/ConvertPaymentActionTest.php
@@ -48,7 +48,7 @@ final class ConvertPaymentActionTest extends TestCase
 
         $action = new ConvertPaymentAction();
 
-        $apiMock = $this->createApiMock(false);
+        $apiMock = $this->createApiMock();
         $apiMock
             ->expects($this->once())
             ->method('getPaymentMethodTypes')
@@ -105,7 +105,7 @@ final class ConvertPaymentActionTest extends TestCase
 
         $action = new ConvertPaymentAction();
 
-        $apiMock = $this->createApiMock(false);
+        $apiMock = $this->createApiMock();
         $apiMock
             ->expects($this->once())
             ->method('getPaymentMethodTypes')
@@ -143,7 +143,7 @@ final class ConvertPaymentActionTest extends TestCase
 
         $action = new ConvertPaymentAction();
 
-        $apiMock = $this->createApiMock(false);
+        $apiMock = $this->createApiMock();
         $apiMock
             ->expects($this->once())
             ->method('getPaymentMethodTypes')
@@ -181,7 +181,7 @@ final class ConvertPaymentActionTest extends TestCase
 
         $action = new ConvertPaymentAction();
 
-        $apiMock = $this->createApiMock(false);
+        $apiMock = $this->createApiMock();
         $apiMock
             ->expects($this->once())
             ->method('getPaymentMethodTypes')
@@ -219,7 +219,7 @@ final class ConvertPaymentActionTest extends TestCase
 
         $action = new ConvertPaymentAction();
 
-        $apiMock = $this->createApiMock(false);
+        $apiMock = $this->createApiMock();
         $apiMock
             ->expects($this->once())
             ->method('getPaymentMethodTypes')
@@ -254,7 +254,7 @@ final class ConvertPaymentActionTest extends TestCase
 
         $action = new ConvertPaymentAction();
 
-        $apiMock = $this->createApiMock(false);
+        $apiMock = $this->createApiMock();
         $apiMock
             ->expects($this->once())
             ->method('getPaymentMethodTypes')

--- a/tests/Action/StripeJs/Api/RenderStripeJsActionTest.php
+++ b/tests/Action/StripeJs/Api/RenderStripeJsActionTest.php
@@ -83,7 +83,7 @@ final class RenderStripeJsActionTest extends TestCase
                 $request->setResult('');
             });
 
-        $apiMock = $this->createApiMock(false);
+        $apiMock = $this->createApiMock();
         $apiMock
             ->expects($this->once())
             ->method('getPublishableKey')

--- a/tests/Api/KeysAwareApiTrait.php
+++ b/tests/Api/KeysAwareApiTrait.php
@@ -4,25 +4,8 @@ declare(strict_types=1);
 
 namespace Tests\FluxSE\PayumStripe\Api;
 
-use FluxSE\PayumStripe\Api\KeysAwareInterface;
-use ReflectionClass;
-
-trait KeysAwareApiTest
+trait KeysAwareApiTrait
 {
-    abstract protected function getApiClass(): string;
-
-    protected function getReflectionApiClass(): ReflectionClass
-    {
-        return new ReflectionClass($this->getApiClass());
-    }
-
-    public function test__construct(): void
-    {
-        $api = $this->getReflectionApiClass()->newInstance('', '');
-
-        $this->assertInstanceOf(KeysAwareInterface::class, $api);
-    }
-
     public function testHasWebhookSecretKey(): void
     {
         $api = $this->getReflectionApiClass()->newInstance('', '', ['webhookKey1']);

--- a/tests/Api/StripeCheckoutSessionApiTest.php
+++ b/tests/Api/StripeCheckoutSessionApiTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\TestCase;
 
 final class StripeCheckoutSessionApiTest extends TestCase
 {
-    use KeysAwareApiTest;
+    use StripeClientAwareApiTrait;
 
     protected function getApiClass(): string
     {

--- a/tests/Api/StripeClientAwareApiTrait.php
+++ b/tests/Api/StripeClientAwareApiTrait.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\FluxSE\PayumStripe\Api;
+
+use FluxSE\PayumStripe\Api\StripeClientAwareInterface;
+use ReflectionClass;
+use Stripe\StripeClient;
+
+trait StripeClientAwareApiTrait
+{
+    use KeysAwareApiTrait;
+    abstract protected function getApiClass(): string;
+
+    protected function getReflectionApiClass(): ReflectionClass
+    {
+        return new ReflectionClass($this->getApiClass());
+    }
+
+    public function test__construct(): void
+    {
+        $api = $this->getReflectionApiClass()->newInstance('', '');
+
+        $this->assertInstanceOf(StripeClientAwareInterface::class, $api);
+    }
+
+    public function testGetClientId(): void
+    {
+        $api = $this->getReflectionApiClass()->newInstance('', '', [], '12345');
+        $this->assertEquals('12345', $api->getClientId());
+    }
+
+    public function testGetStripeAccount(): void
+    {
+        $api = $this->getReflectionApiClass()->newInstance('', '', [], null, '12345');
+        $this->assertEquals('12345', $api->getStripeAccount());
+    }
+
+    public function testGetStripeVersion(): void
+    {
+        $api = $this->getReflectionApiClass()->newInstance('', '', [], null, null, '1');
+        $this->assertEquals('1', $api->getStripeVersion());
+    }
+
+    public function testGetStripeClient(): void
+    {
+        $api = $this->getReflectionApiClass()->newInstance('', '12345');
+        $this->assertInstanceOf(StripeClient::class, $api->getStripeClient());
+    }
+}

--- a/tests/Api/StripeJsApiTest.php
+++ b/tests/Api/StripeJsApiTest.php
@@ -8,7 +8,7 @@ use PHPUnit\Framework\TestCase;
 
 final class StripeJsApiTest extends TestCase
 {
-    use KeysAwareApiTest;
+    use StripeClientAwareApiTrait;
 
     protected function getApiClass(): string
     {

--- a/tests/Request/Api/Resource/AllTest.php
+++ b/tests/Request/Api/Resource/AllTest.php
@@ -9,6 +9,9 @@ use FluxSE\PayumStripe\Request\Api\Resource\AllCoupon;
 use FluxSE\PayumStripe\Request\Api\Resource\AllCustomer;
 use FluxSE\PayumStripe\Request\Api\Resource\AllInterface;
 use FluxSE\PayumStripe\Request\Api\Resource\AllInvoice;
+use FluxSE\PayumStripe\Request\Api\Resource\AllPlan;
+use FluxSE\PayumStripe\Request\Api\Resource\AllPrice;
+use FluxSE\PayumStripe\Request\Api\Resource\AllProduct;
 use FluxSE\PayumStripe\Request\Api\Resource\AllSession;
 use FluxSE\PayumStripe\Request\Api\Resource\AllTaxRate;
 use FluxSE\PayumStripe\Request\Api\Resource\OptionsAwareInterface;
@@ -20,6 +23,9 @@ use Stripe\Collection;
 use Stripe\Coupon;
 use Stripe\Customer;
 use Stripe\Invoice;
+use Stripe\Plan;
+use Stripe\Price;
+use Stripe\Product;
 use Stripe\TaxRate;
 
 final class AllTest extends TestCase
@@ -107,6 +113,9 @@ final class AllTest extends TestCase
             [AllCoupon::class, Coupon::class],
             [AllCustomer::class, Customer::class],
             [AllInvoice::class, Invoice::class],
+            [AllPlan::class, Plan::class],
+            [AllPrice::class, Price::class],
+            [AllProduct::class, Product::class],
             [AllTaxRate::class, TaxRate::class],
             [AllSession::class, Session::class],
         ];

--- a/tests/Request/Api/Resource/CreateTest.php
+++ b/tests/Request/Api/Resource/CreateTest.php
@@ -8,6 +8,8 @@ use FluxSE\PayumStripe\Request\Api\Resource\CreateInterface;
 use FluxSE\PayumStripe\Request\Api\Resource\CreatePaymentIntent;
 use FluxSE\PayumStripe\Request\Api\Resource\CreatePaymentMethod;
 use FluxSE\PayumStripe\Request\Api\Resource\CreatePlan;
+use FluxSE\PayumStripe\Request\Api\Resource\CreatePrice;
+use FluxSE\PayumStripe\Request\Api\Resource\CreateProduct;
 use FluxSE\PayumStripe\Request\Api\Resource\CreateRefund;
 use FluxSE\PayumStripe\Request\Api\Resource\CreateSession;
 use FluxSE\PayumStripe\Request\Api\Resource\CreateSubscription;
@@ -24,6 +26,8 @@ use Stripe\Customer;
 use Stripe\PaymentIntent;
 use Stripe\PaymentMethod;
 use Stripe\Plan;
+use Stripe\Price;
+use Stripe\Product;
 use Stripe\Refund;
 use Stripe\Subscription;
 use Stripe\TaxRate;
@@ -126,6 +130,8 @@ final class CreateTest extends TestCase
             [CreatePaymentIntent::class, PaymentIntent::class],
             [CreatePaymentMethod::class, PaymentMethod::class],
             [CreatePlan::class, Plan::class],
+            [CreatePrice::class, Price::class],
+            [CreateProduct::class, Product::class],
             [CreateRefund::class, Refund::class],
             [CreateSubscription::class, Subscription::class],
             [CreateTaxRate::class, TaxRate::class],

--- a/tests/Request/Api/Resource/DeleteTest.php
+++ b/tests/Request/Api/Resource/DeleteTest.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace Tests\FluxSE\PayumStripe\Request\Api\Resource;
 
 use FluxSE\PayumStripe\Request\Api\Resource\AbstractDelete;
+use FluxSE\PayumStripe\Request\Api\Resource\DeleteCoupon;
 use FluxSE\PayumStripe\Request\Api\Resource\DeleteInterface;
 use FluxSE\PayumStripe\Request\Api\Resource\DeletePlan;
+use FluxSE\PayumStripe\Request\Api\Resource\DeleteProduct;
 use FluxSE\PayumStripe\Request\Api\Resource\OptionsAwareInterface;
 use FluxSE\PayumStripe\Request\Api\Resource\ResourceAwareInterface;
 use LogicException;
@@ -14,7 +16,9 @@ use Payum\Core\Request\Generic;
 use PHPUnit\Framework\TestCase;
 use Stripe\ApiOperations\Delete;
 use Stripe\ApiResource;
+use Stripe\Coupon;
 use Stripe\Plan;
+use Stripe\Product;
 
 final class DeleteTest extends TestCase
 {
@@ -98,7 +102,9 @@ final class DeleteTest extends TestCase
     public function requestList(): array
     {
         return [
+            [DeleteCoupon::class, Coupon::class],
             [DeletePlan::class, Plan::class],
+            [DeleteProduct::class, Product::class],
         ];
     }
 }

--- a/tests/Request/Api/Resource/RetrieveTest.php
+++ b/tests/Request/Api/Resource/RetrieveTest.php
@@ -12,6 +12,7 @@ use FluxSE\PayumStripe\Request\Api\Resource\RetrieveInvoice;
 use FluxSE\PayumStripe\Request\Api\Resource\RetrievePaymentIntent;
 use FluxSE\PayumStripe\Request\Api\Resource\RetrievePaymentMethod;
 use FluxSE\PayumStripe\Request\Api\Resource\RetrievePlan;
+use FluxSE\PayumStripe\Request\Api\Resource\RetrievePrice;
 use FluxSE\PayumStripe\Request\Api\Resource\RetrieveProduct;
 use FluxSE\PayumStripe\Request\Api\Resource\RetrieveSession;
 use FluxSE\PayumStripe\Request\Api\Resource\RetrieveSetupIntent;
@@ -28,6 +29,7 @@ use Stripe\Invoice;
 use Stripe\PaymentIntent;
 use Stripe\PaymentMethod;
 use Stripe\Plan;
+use Stripe\Price;
 use Stripe\Product;
 use Stripe\SetupIntent;
 use Stripe\Subscription;
@@ -120,6 +122,7 @@ final class RetrieveTest extends TestCase
             [RetrievePaymentIntent::class, PaymentIntent::class],
             [RetrievePaymentMethod::class, PaymentMethod::class],
             [RetrievePlan::class, Plan::class],
+            [RetrievePrice::class, Price::class],
             [RetrieveProduct::class, Product::class],
             [RetrieveSession::class, Session::class],
             [RetrieveSetupIntent::class, SetupIntent::class],

--- a/tests/Request/Api/Resource/UpdateTest.php
+++ b/tests/Request/Api/Resource/UpdateTest.php
@@ -8,12 +8,20 @@ use FluxSE\PayumStripe\Request\Api\Resource\AbstractUpdate;
 use FluxSE\PayumStripe\Request\Api\Resource\OptionsAwareInterface;
 use FluxSE\PayumStripe\Request\Api\Resource\ResourceAwareInterface;
 use FluxSE\PayumStripe\Request\Api\Resource\UpdateInterface;
+use FluxSE\PayumStripe\Request\Api\Resource\UpdatePaymentIntent;
+use FluxSE\PayumStripe\Request\Api\Resource\UpdatePlan;
+use FluxSE\PayumStripe\Request\Api\Resource\UpdatePrice;
+use FluxSE\PayumStripe\Request\Api\Resource\UpdateProduct;
 use FluxSE\PayumStripe\Request\Api\Resource\UpdateSubscription;
 use LogicException;
 use Payum\Core\Request\Generic;
 use PHPUnit\Framework\TestCase;
 use Stripe\ApiOperations\Update;
 use Stripe\ApiResource;
+use Stripe\PaymentIntent;
+use Stripe\Plan;
+use Stripe\Price;
+use Stripe\Product;
 use Stripe\Subscription;
 
 final class UpdateTest extends TestCase
@@ -110,6 +118,10 @@ final class UpdateTest extends TestCase
     public function requestList(): array
     {
         return [
+            [UpdatePaymentIntent::class, PaymentIntent::class],
+            [UpdatePlan::class, Plan::class],
+            [UpdatePrice::class, Price::class],
+            [UpdateProduct::class, Product::class],
             [UpdateSubscription::class, Subscription::class],
         ];
     }


### PR DESCRIPTION
`stripe/stripe-php` has evolved since v9, this PR aim to support newer version : v12.

This PR also add support for new options :

- `client_id` 
- `stripe_account`
- `stripe_version`

Those new options are supported to be able to control the `StripeClient` : https://github.com/stripe/stripe-php/blob/master/lib/BaseStripeClient.php#L19-L21

