### PR TITLE
Avoid duplicate using idempotency key

### DIFF
--- a/src/Action/AbstractCaptureAction.php
+++ b/src/Action/AbstractCaptureAction.php
@@ -85,7 +85,12 @@ abstract class AbstractCaptureAction implements ActionInterface, GatewayAwareInt
             return null;
         }
 
-        $id = (string) $token->getDetails()->getId();
+        $id = $token->getDetails()->getId();
+        if (false === is_scalar($id)) {
+            return null;
+        }
+
+        $id = (string) $id;
         if ('' === $id) {
             return null;
         }

--- a/src/Action/AbstractCaptureAction.php
+++ b/src/Action/AbstractCaptureAction.php
@@ -63,6 +63,36 @@ abstract class AbstractCaptureAction implements ActionInterface, GatewayAwareInt
         $this->gateway->execute(new Sync($model));
     }
 
+    /**
+     * @return array<string, mixed>
+     */
+    protected function getApiResourceOptions(Generic $request): array
+    {
+        $options = [];
+
+        $idempotencyKey = $this->getIdempotencyKey($request);
+        if (null !== $idempotencyKey) {
+            $options['idempotency_key'] = $idempotencyKey;
+        }
+
+        return $options;
+    }
+
+    protected function getIdempotencyKey(Generic $request): ?string
+    {
+        $token = $request->getToken();
+        if (null === $token) {
+            return null;
+        }
+
+        $id = (string) $token->getDetails()->getId();
+        if ('' === $id) {
+            return null;
+        }
+
+        return md5($id);
+    }
+
     abstract protected function createApiResource(BaseArrayObject $model, Generic $request): ApiResource;
 
     abstract protected function render(ApiResource $captureResource, Generic $request): void;

--- a/src/Action/StripeCheckoutSession/CaptureAction.php
+++ b/src/Action/StripeCheckoutSession/CaptureAction.php
@@ -22,7 +22,10 @@ class CaptureAction extends AbstractCaptureAction
         $model->offsetSet('success_url', $token->getAfterUrl());
         $model->offsetSet('cancel_url', $token->getAfterUrl());
 
-        $createRequest = new CreateSession($model->getArrayCopy());
+        $createRequest = new CreateSession(
+            $model->getArrayCopy(),
+            $this->getApiResourceOptions($request)
+        );
         $this->gateway->execute($createRequest);
 
         return $createRequest->getApiResource();

--- a/src/Action/StripeJs/CaptureAction.php
+++ b/src/Action/StripeJs/CaptureAction.php
@@ -16,7 +16,10 @@ class CaptureAction extends AbstractCaptureAction
 {
     protected function createApiResource(ArrayObject $model, Generic $request): ApiResource
     {
-        $createRequest = new CreatePaymentIntent($model->getArrayCopy());
+        $createRequest = new CreatePaymentIntent(
+            $model->getArrayCopy(),
+            $this->getApiResourceOptions($request)
+        );
         $this->gateway->execute($createRequest);
 
         return $createRequest->getApiResource();


### PR DESCRIPTION
This pull request introduces a new mechanism for generating and passing idempotency keys to Stripe API resource creation requests, improving reliability and preventing duplicate resource creation. It also updates related tests to verify the correct handling of these options and refactors test mocks for better maintainability.

### Idempotency key handling

* Added `getApiResourceOptions` and `getIdempotencyKey` helper methods to `AbstractCaptureAction`, which compute an idempotency key from the request token and return it in the options array for API resource creation.
* Updated `StripeCheckoutSession/CaptureAction` and `StripeJs/CaptureAction` to pass the new options (including the idempotency key) when constructing `CreateSession` and `CreatePaymentIntent` requests. [[1]](diffhunk://#diff-8d55d4c8eca79e248a926b88f96b2e26e9651c1071815c7a44a0a31ed6270eafL25-R28) [[2]](diffhunk://#diff-2cdbf25903c376b73b8fc7a1e75aa64d15fdf5d085725f6a5f5cafca66490780L19-R22)

### Test improvements

* Refactored test mocks in `StripeCheckoutSession/CaptureActionTest` and `StripeJs/CaptureActionTest` to use a callback for verifying the sequence and type of gateway requests, replacing the previous `withConsecutive` approach. [[1]](diffhunk://#diff-c3fc64510daa043693c0381e74f295e3c13eb53bbba35c0a550ea1521fb0ec7cL58-R70) [[2]](diffhunk://#diff-200163e73766ebe20697cc14ae8798c58e225db755354d79cecab3f908324feeL55-R67)
* Enhanced tests to assert that the correct idempotency key is included in options for API resource creation requests. [[1]](diffhunk://#diff-c3fc64510daa043693c0381e74f295e3c13eb53bbba35c0a550ea1521fb0ec7cL102-R130) [[2]](diffhunk://#diff-200163e73766ebe20697cc14ae8798c58e225db755354d79cecab3f908324feeL99-R127)