### PR TITLE
Support multiple Stripe SDK versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,12 +22,27 @@ jobs:
     tests:
         runs-on: ubuntu-latest
 
-        name: "PHP ${{ matrix.php }}"
+        name: "PHP ${{ matrix.php-version }} / Stripe ${{ matrix.stripe-version }}"
 
         strategy:
             fail-fast: false
             matrix:
-                php: [7.2, 7.3, 7.4, 8.0, 8.1]
+                php-version:
+                    - 7.2
+                    - 7.3
+                    - 7.4
+                    - 8.0
+                    - 8.1
+                    - 8.2
+                    - 8.3
+                    - 8.4
+                stripe-version:
+                    - 12
+                    - 13
+                    - 14
+                    - 15
+                    - 16
+                    - 17
 
         steps:
             -
@@ -37,7 +52,7 @@ jobs:
                 name: Setup PHP
                 uses: shivammathur/setup-php@v2
                 with:
-                    php-version: "${{ matrix.php }}"
+                    php-version: "${{ matrix.php-version }}"
                     coverage: xdebug
 
             -
@@ -50,9 +65,13 @@ jobs:
                 uses: actions/cache@v3
                 with:
                     path: ${{ steps.composer-cache.outputs.dir }}
-                    key: ${{ runner.os }}-php-${{ matrix.php }}-composer-${{ hashFiles('**/composer.json **/composer.lock') }}
+                    key: ${{ runner.os }}-php-${{ matrix.php-version }}-stripe-${{ matrix.stripe-version }}-composer-${{ hashFiles('**/composer.json **/composer.lock') }}
                     restore-keys: |
-                        ${{ runner.os }}-php-${{ matrix.php }}-composer-
+                      ${{ runner.os }}-php-${{ matrix.php-version }}-stripe-${{ matrix.stripe-version }}-composer-
+
+            -
+                name: Require Stripe version
+                run: composer require stripe/stripe-php:^${{ matrix.stripe-version }} --no-interaction --no-update
 
             -
                 name: Install PHP dependencies

--- a/composer.json
+++ b/composer.json
@@ -9,8 +9,9 @@
         "authorize"
     ],
     "require": {
+        "php": "^7.2|^8.0",
         "payum/core": "^1.6",
-        "stripe/stripe-php": "^12"
+        "stripe/stripe-php": "^12|^13|^14|^15|^16|^17"
     },
     "require-dev": {
         "phpunit/phpunit": "^8|^9",

--- a/src/Request/Api/ResolveWebhookEvent.php
+++ b/src/Request/Api/ResolveWebhookEvent.php
@@ -10,7 +10,7 @@ use Payum\Core\Security\TokenInterface;
 
 final class ResolveWebhookEvent extends Convert
 {
-    public function __construct(TokenInterface $token = null)
+    public function __construct(?TokenInterface $token = null)
     {
         parent::__construct(null, EventWrapperInterface::class, $token);
     }


### PR DESCRIPTION
This PR targets #51

I have added the required PHP version `^7.2|^8.0` explicitly in `composer.json`.
I started from `^7.2` because this version was tested in GitHub action. I would suggest dropping explicit support for such old versions, but this can be addressed in future PRs.

I added to the test matrix all newer PHP versions, as PHP `^8.1` was the latest beeing tested.

I added all current existing `stripe/stripe-php` released versions to the matrix, and this list should be updated every time a new SDK version is supported.

I have made a small change in `src/Request/Api/ResolveWebhookEvent.php` only to not have PHP deprecation notices in newer PHP versions.

I can not test the full matrix of `stripe/stripe-php` and `FLUX-SE/PayumStripe` in my projects, so I will rely on others to test a bit more. 
I think this PR can be merged and developers can opt-in into the required `stripe/stripe-php` version and report back if someting is not working.