### PR TITLE
Re-render Stripe JS Elements form when reusing a still-payable PaymentIntent

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,15 @@
         "ext-json": "*",
         "php-http/message-factory": "^1.1"
     },
+    "config": {
+        "policy": {
+            "advisories": {
+                "ignore": {
+                    "twig/twig": "Pulled in transitively by payum/core; no patched release supports the PHP 7.2/7.4 versions this library still targets."
+                }
+            }
+        }
+    },
     "autoload": {
         "psr-4": { "FluxSE\\PayumStripe\\": "src/" }
     },

--- a/src/Action/StripeJs/CaptureAction.php
+++ b/src/Action/StripeJs/CaptureAction.php
@@ -11,9 +11,20 @@ use FluxSE\PayumStripe\Request\CaptureAuthorized;
 use FluxSE\PayumStripe\Request\StripeJs\Api\RenderStripeJs;
 use Payum\Core\Request\Generic;
 use Stripe\ApiResource;
+use Stripe\PaymentIntent;
 
 class CaptureAction extends AbstractCaptureAction
 {
+    /**
+     * PaymentIntent statuses that still require the buyer to pay, i.e. the Elements form
+     * must be (re)rendered so the very same intent can be confirmed.
+     */
+    private const PAYABLE_PAYMENT_INTENT_STATUSES = [
+        PaymentIntent::STATUS_REQUIRES_PAYMENT_METHOD,
+        PaymentIntent::STATUS_REQUIRES_CONFIRMATION,
+        PaymentIntent::STATUS_REQUIRES_ACTION,
+    ];
+
     protected function createApiResource(ArrayObject $model, Generic $request): ApiResource
     {
         $createRequest = new CreatePaymentIntent($model->getArrayCopy());
@@ -40,5 +51,17 @@ class CaptureAction extends AbstractCaptureAction
         $captureAuthorizedRequest = new CaptureAuthorized($this->getRequestToken($request));
         $captureAuthorizedRequest->setModel($model);
         $this->gateway->execute($captureAuthorizedRequest);
+
+        // When the PaymentIntent is reused while still awaiting payment (e.g. the buyer reloaded
+        // the payment page before paying), re-render the Stripe Elements form so the very same
+        // intent can be confirmed — without this, Payum would redirect to the after URL and leave
+        // the buyer unable to complete the payment.
+        /** @var string|null $status */
+        $status = $model->offsetGet('status');
+        if (!in_array($status, self::PAYABLE_PAYMENT_INTENT_STATUSES, true)) {
+            return;
+        }
+
+        $this->render(PaymentIntent::constructFrom($model->getArrayCopy()), $request);
     }
 }

--- a/tests/Action/StripeJs/CaptureActionTest.php
+++ b/tests/Action/StripeJs/CaptureActionTest.php
@@ -71,6 +71,49 @@ final class CaptureActionTest extends TestCase
         $action->execute($request);
     }
 
+    public function testShouldRenderAStripeJsTemplateWhenReusingAPayablePaymentIntent(): void
+    {
+        $model = [
+            'id' => 'pi_0001',
+            'status' => PaymentIntent::STATUS_REQUIRES_PAYMENT_METHOD,
+        ];
+
+        $token = new Token();
+        $token->setAfterUrl('test/url');
+
+        $gatewayMock = $this->createGatewayMock();
+        $gatewayMock
+            ->expects($this->exactly(3))
+            ->method('execute')
+            ->withConsecutive(
+                [$this->isInstanceOf(Sync::class)],
+                [$this->isInstanceOf(CaptureAuthorized::class)],
+                [$this->isInstanceOf(RenderStripeJs::class)]
+            )
+            ->willReturnOnConsecutiveCalls(
+                $this->returnCallback(function (Sync $request): void {
+                    // keep the payable status set on the synced model
+                    $this->assertInstanceOf(ArrayObject::class, $request->getModel());
+                }),
+                $this->returnCallback(function (CaptureAuthorized $request): void {
+                    $this->assertInstanceOf(ArrayObject::class, $request->getModel());
+                }),
+                $this->throwException(new HttpResponse(''))
+            )
+        ;
+
+        $action = new CaptureAction();
+        $action->setGateway($gatewayMock);
+
+        $request = new Capture($token);
+        $request->setModel($model);
+
+        $this->assertTrue($action->supports($request));
+
+        $this->expectException(HttpResponse::class);
+        $action->execute($request);
+    }
+
     public function shouldThrowExceptionWhenThereIsNoTokenAvailable(): void
     {
         $model = [];


### PR DESCRIPTION
Solves https://github.com/Sylius/PayumStripePlugin/issues/76, connected with https://github.com/Sylius/PayumStripePlugin/pull/80#issuecomment-4678076105

### Problem

With the Stripe JS gateway, a Capture whose model already carries a PaymentIntent id takes the reuse path (`CaptureAction::processNotNew()`), which only syncs the intent and runs CaptureAuthorized — it never re-renders the Elements form. So when a buyer reloads the payment page before paying, the still-payable intent (requires_payment_method / requires_confirmation / requires_action) is redirected to the after URL instead of showing the form again, leaving them unable to pay and the intent stuck incomplete.

### Fix

Re-render the Stripe Elements form at the end of `processNotNew()` when the synced PaymentIntent is still in a payable state, so the very same intent can be confirmed. Terminal/awaiting-capture states (succeeded, processing, requires_capture, canceled) fall through to the existing redirect — unchanged.

Reusing the existing intent (rather than cancel-and-recreate) is intentional and concurrency-safe: the client_secret is bound to a specific PaymentIntent on the already-rendered page.